### PR TITLE
Feature - DateTime subtract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.0
+
+- Added comprehensive `DateTime` subtraction extensions with calendar-aware date arithmetic
+- Added `DateTimeSubtractMonthsAndYearsExtension` with `subtractMonths`, `subtractYears`, `subtractMonth`, `subtractYear` methods
+- Added `DateTimeSubtractExtendingYearsExtension` with `subtractDecades`, `subtractCenturies`, `subtractDecade`, `subtractCentury` methods
+- Works better than "adding minus days" or "adding minus weeks"
+
 ## 1.1.6
 
 - Added `DateTimeNextExtensions` extension on `DateTime` class:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Stop wrestling with `DateTime` and `Duration`. `time_plus` gives you the tools y
 #### 📅 `DateTime`
 
 - [**add**](#-add--add-time-to-a-datetime) – Add time units to `DateTime` from milliseconds to centuries with `.addX()` or `.addX` getters.
+- [**subtract**](#-subtract--subtract-time-from-a-datetime) – Subtract time units from `DateTime` using intuitive, calendar-aware methods.
 - [**isSame**](#-issame--compare-temporal-precision) – Compare two dates by year, month, day, hour, to microseconds using `isSameX()`.
 - [**startOf / endOf**](#-startof--endof--datetime-boundaries) – Get start or end of time units: minute, hour, day, week, month, year.
 - [**next**](#️-next--find-the-next-matching-datetime) – Find the next matching `DateTime` by weekday or time of day.
@@ -32,7 +33,7 @@ Stop wrestling with `DateTime` and `Duration`. `time_plus` gives you the tools y
 - [**add**](#-add--add-time-units-to-a-duration) – Chain any time unit, from microseconds to centuries, with `.addX()` or `.addX` getters.
 - [**in**](#-in--convert-duration-to-whole-units) – Convert durations into whole units like `inWeeks`, `inYears`, or `inCenturies`.
 - [**only**](#-only--break-down-duration-by-remaining-units) – Extract the remainder after subtracting larger units (e.g. `onlyMinutes`, `onlySeconds`).
-- [**without**](#-without--remove-full-units-from-a-duration) – Strip full units to isolate what’s left (e.g. time since midnight).
+- [**without**](#-without--remove-full-units-from-a-duration) – Strip full units to isolate what's left (e.g. time since midnight).
 - [**Factories**](#️-factories--create-durations-from-any-unit) – Create durations from any unit or use built-in constants like `DurationFrom.year`.
 
 ## Why Use `time_plus`?
@@ -47,7 +48,7 @@ Stop wrestling with `DateTime` and `Duration`. `time_plus` gives you the tools y
   - 🧮 **Data handling** – Grouping, filtering, and comparing `DateTime` objects with precision
   - ⏱️ **UI & analytics** – Formatting durations, tracking activity, and displaying time intuitively
 
-`time_plus` closes the gaps in Dart’s native `DateTime` and `Duration` APIs — making your code easier to write, easier to read, and easier to trust.
+`time_plus` closes the gaps in Dart's native `DateTime` and `Duration` APIs — making your code easier to write, easier to read, and easier to trust.
 
 ---
 
@@ -59,7 +60,7 @@ Extend `DateTime` just like you wish it worked. These extensions let you safely 
 - `addSeconds(int)` / `addSecond`
 - `addMinutes(int)` / `addMinute`
 - `addHours(int)` / `addHour`
-- `addDays(int)` / `addDay`
+- `addDays(int)` / `addDay` — Preserves exact time of day (all following methods do)
 - `addWeeks(int)` / `addWeek`
 - `addMonths(int)` / `addMonth`
 - `addYears(int)` / `addYear`
@@ -77,6 +78,41 @@ final chained = now.addYear.addYear.addMonth; // → 2026-03-29
 final future = now.addDecades(2);             // → 2044-02-29
 final long = now.addCenturies(1);             // → 2124-02-29
 ```
+
+> **Important:** The `addDays` and `addWeeks` and the bigger time units methods preserve the exact time of day and are calendar-aware, making them safe for daylight saving time transitions. They are not equivalent to adding hours.
+
+_[⤴️ Back](#table-of-contents) -> Table of Contents_
+
+---
+
+### ➖ `subtract` — Subtract Time from a `DateTime`
+
+Safely subtract time from any `DateTime` using intuitive, calendar-aware methods. These extensions go beyond raw durations to handle months, years, decades, and centuries — correctly accounting for leap years, daylight saving, and invalid dates like Feb 30.
+
+- `subtractMilliseconds(int)` / `subtractMillisecond`
+- `subtractSeconds(int)` / `subtractSecond`
+- `subtractMinutes(int)` / `subtractMinute`
+- `subtractHours(int)` / `subtractHour`
+- `subtractDays(int)` / `subtractDay` — Preserves exact time of day (all following methods do)
+- `subtractWeeks(int)` / `subtractWeek`
+- `subtractMonths(int)` / `subtractMonth`
+- `subtractYears(int)` / `subtractYear`
+- `subtractDecades(int)` / `subtractDecade` (10-year spans)
+- `subtractCenturies(int)` / `subtractCentury` (100-year spans)
+
+All methods return a new `DateTime` instance. Month and year-based methods clamp invalid dates (e.g. March 31 → February 28/29), ensuring always-valid results.
+
+#### 🧪 Example
+
+```dart
+final now = DateTime(2024, 2, 29);
+final lastYear = now.subtractYear;                 // → 2023-02-28
+final chained = now.subtractYear.subtractMonth;    // → 2022-01-28
+final past = now.subtractDecades(2);               // → 2004-02-29
+final wayBack = now.subtractCenturies(1);          // → 1924-02-29
+```
+
+> **Important:** The `subtractDays` and `subtractWeeks` and the bigger time units methods preserve the exact time of day and are calendar-aware, making them safe for daylight saving time transitions. They are not equivalent to subtracting hours.
 
 _[⤴️ Back](#table-of-contents) -> Table of Contents_
 
@@ -177,8 +213,8 @@ _[⤴️ Back](#table-of-contents) -> Table of Contents_
 Easily check if a `DateTime` falls in a leap year, on a leap month (February in a leap year), or on the rarest of all — leap day itself (Feb 29).
 
 - `isLeapYear` — `true` if the year has 366 days
-- `isLeapMonth` — `true` if it’s February in a leap year
-- `isLeapDay` — `true` if it’s exactly February 29
+- `isLeapMonth` — `true` if it's February in a leap year
+- `isLeapDay` — `true` if it's exactly February 29
 
 #### 🧪 Example
 

--- a/lib/src/date_time/add/durations.dart
+++ b/lib/src/date_time/add/durations.dart
@@ -49,10 +49,14 @@ extension DateTimeAddDurationExtension on DateTime {
 
   /// Returns a new [DateTime] with the specified number of [days] added.
   ///
+  /// This method preserves the exact time of day and is not equivalent to adding
+  /// 24 hours. It will keep the same time but move to the specified number of
+  /// days in the future, which is important for daylight saving time handling.
+  ///
   /// Example:
   /// ```dart
   /// DateTime now = DateTime.now();
-  /// DateTime future = now.addDays(7);
+  /// DateTime future = now.addDays(7); // Same time, 7 days later
   /// ```
   DateTime addDays(int days) {
     return copyWithSameUtcFlag(day: day + days);
@@ -60,10 +64,14 @@ extension DateTimeAddDurationExtension on DateTime {
 
   /// Returns a new [DateTime] with the specified number of [weeks] added.
   ///
+  /// This method preserves the exact time of day and is not equivalent to adding
+  /// 168 hours (7 × 24). It will keep the same time but move to the specified
+  /// number of weeks in the future, which is important for daylight saving time handling.
+  ///
   /// Example:
   /// ```dart
   /// DateTime now = DateTime.now();
-  /// DateTime future = now.addWeeks(3);
+  /// DateTime future = now.addWeeks(3); // Same time, 3 weeks later
   /// ```
   DateTime addWeeks(int weeks) {
     return addDays(weeks * TimePlusConsts.daysInWeek);

--- a/lib/src/date_time/add/durations.dart
+++ b/lib/src/date_time/add/durations.dart
@@ -1,4 +1,5 @@
 import '../../consts.dart';
+import '../utc_flag.dart';
 
 /// Extension on [DateTime] to add various durations.
 extension DateTimeAddDurationExtension on DateTime {
@@ -54,7 +55,7 @@ extension DateTimeAddDurationExtension on DateTime {
   /// DateTime future = now.addDays(7);
   /// ```
   DateTime addDays(int days) {
-    return add(Duration(days: days));
+    return copyWithSameUtcFlag(day: day + days);
   }
 
   /// Returns a new [DateTime] with the specified number of [weeks] added.
@@ -65,7 +66,7 @@ extension DateTimeAddDurationExtension on DateTime {
   /// DateTime future = now.addWeeks(3);
   /// ```
   DateTime addWeeks(int weeks) {
-    return add(Duration(days: weeks * TimePlusConsts.daysInWeek));
+    return addDays(weeks * TimePlusConsts.daysInWeek);
   }
 
   /// Returns a new [DateTime] with one millisecond added.

--- a/lib/src/date_time/add/month_and_year.dart
+++ b/lib/src/date_time/add/month_and_year.dart
@@ -1,3 +1,4 @@
+import '../utc_flag.dart';
 import '../../consts.dart';
 
 /// Extension on [DateTime] to add months and years, with proper handling of month overflow and leap years.
@@ -64,6 +65,11 @@ extension DateTimeAddMonthsAndYearsExtension on DateTime {
   DateTime _createDateTimeWithClampedDay(int newYear, int newMonth) {
     final lastDayOfMonth = DateTime(newYear, newMonth + 1, 0).day;
     final newDay = day.clamp(1, lastDayOfMonth);
-    return DateTime(newYear, newMonth, newDay);
+    // preserve the original time-of-day and UTC/local flag:
+    return copyWithSameUtcFlag(
+      year: newYear,
+      month: newMonth,
+      day: newDay,
+    );
   }
 }

--- a/lib/src/date_time/boundaries.dart
+++ b/lib/src/date_time/boundaries.dart
@@ -1,4 +1,5 @@
 import '../consts.dart';
+import 'utc_flag.dart';
 
 extension DateTimeBoundariesExtensions on DateTime {
   /// Returns a [DateTime] representing the start of the current millisecond.
@@ -6,7 +7,9 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, hour, minute, second, and millisecond
   /// as the original, but with microseconds set to zero.
   DateTime get startOfMillisecond {
-    return _withSameZone(year, month, day, hour, minute, second, millisecond);
+    return copyWithSameUtcFlag(
+      microsecond: 0,
+    );
   }
 
   /// Returns a [DateTime] representing the end of the current millisecond.
@@ -14,8 +17,10 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, hour, minute, second, and millisecond
   /// as the original, but with microseconds set to zero.
   DateTime get endOfMillisecond {
-    return _withSameZone(
-        year, month, day, hour, minute, second, millisecond + 1);
+    return copyWithSameUtcFlag(
+      millisecond: millisecond + 1,
+      microsecond: 0,
+    );
   }
 
   /// Returns a [DateTime] representing the start of the current second.
@@ -23,7 +28,10 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, hour, minute, and second
   /// as the original, but with milliseconds and microseconds set to zero.
   DateTime get startOfSecond {
-    return _withSameZone(year, month, day, hour, minute, second);
+    return copyWithSameUtcFlag(
+      millisecond: 0,
+      microsecond: 0,
+    );
   }
 
   /// Returns a [DateTime] representing the end of the current second.
@@ -31,7 +39,11 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, hour, minute, and second
   /// as the original, but with milliseconds and microseconds set to zero.
   DateTime get endOfSecond {
-    return _withSameZone(year, month, day, hour, minute, second + 1);
+    return copyWithSameUtcFlag(
+      second: second + 1,
+      millisecond: 0,
+      microsecond: 0,
+    );
   }
 
   /// Returns a [DateTime] representing the start of the current minute.
@@ -39,7 +51,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, hour, and minute
   /// as the original, but with seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfMinute {
-    return _withSameZone(year, month, day, hour, minute);
+    return withSameUtcFlag(year, month, day, hour, minute);
   }
 
   /// Returns a [DateTime] representing the end of the current minute.
@@ -47,7 +59,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, and hour as the original,
   /// but the minute is incremented by one, with seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfMinute {
-    return _withSameZone(year, month, day, hour, minute + 1);
+    return withSameUtcFlag(year, month, day, hour, minute + 1);
   }
 
   /// Returns a [DateTime] representing the start of the current hour.
@@ -55,7 +67,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, day, and hour as the original,
   /// but with minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfHour {
-    return _withSameZone(year, month, day, hour);
+    return withSameUtcFlag(year, month, day, hour);
   }
 
   /// Returns a [DateTime] representing the end of the current hour.
@@ -63,7 +75,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, and day as the original,
   /// but the hour is incremented by one, with minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfHour {
-    return _withSameZone(year, month, day, hour + 1);
+    return withSameUtcFlag(year, month, day, hour + 1);
   }
 
   /// Returns a [DateTime] representing the start of the current day.
@@ -71,7 +83,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year, month, and day as the original,
   /// but with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfDay {
-    return _withSameZone(year, month, day);
+    return withSameUtcFlag(year, month, day);
   }
 
   /// Returns a [DateTime] representing the end of the current day.
@@ -79,7 +91,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year and month as the original,
   /// but the day is incremented by one, with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfDay {
-    return _withSameZone(year, month, day + 1);
+    return withSameUtcFlag(year, month, day + 1);
   }
 
   /// Returns a [DateTime] representing the start of the current week.
@@ -88,7 +100,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// it is adjusted to the previous year's last week.
   DateTime get startOfWeek {
     final monday =
-        _withSameZone(year, month, day).subtract(Duration(days: weekday - 1));
+        withSameUtcFlag(year, month, day).subtract(Duration(days: weekday - 1));
 
     if (month == 1 && monday.month == 1 && monday.day == 1) {
       return monday.subtract(const Duration(days: 7));
@@ -109,7 +121,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year and month as the original,
   /// but the day is set to the first, with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfMonth {
-    return _withSameZone(year, month, 1);
+    return withSameUtcFlag(year, month, 1);
   }
 
   /// Returns a [DateTime] representing the end of the current month.
@@ -118,7 +130,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// but the month is incremented by one, with the day set to the first,
   /// and hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfMonth {
-    return _withSameZone(year, month + 1, 1);
+    return withSameUtcFlag(year, month + 1, 1);
   }
 
   /// Returns a [DateTime] representing the start of the current year.
@@ -126,7 +138,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year as the original,
   /// but the month and day are set to January 1st, with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfYear {
-    return _withSameZone(year, 1, 1);
+    return withSameUtcFlag(year, 1, 1);
   }
 
   /// Returns a [DateTime] representing the end of the current year.
@@ -134,7 +146,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the year incremented by one,
   /// with the month and day set to January 1st, and hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfYear {
-    return _withSameZone(year + 1, 1, 1);
+    return withSameUtcFlag(year + 1, 1, 1);
   }
 
   /// Returns a [DateTime] representing the start of the current decade.
@@ -142,7 +154,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year as the original,
   /// but the month and day are set to January 1st, with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfDecade {
-    return _withSameZone(year - year % TimePlusConsts.yearsInDecade, 1, 1);
+    return withSameUtcFlag(year - year % TimePlusConsts.yearsInDecade, 1, 1);
   }
 
   /// Returns a [DateTime] representing the end of the current decade.
@@ -150,7 +162,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the year incremented by ten,
   /// with the month and day set to January 1st, and hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfDecade {
-    return _withSameZone(
+    return withSameUtcFlag(
         year -
             year % TimePlusConsts.yearsInDecade +
             TimePlusConsts.yearsInDecade,
@@ -163,7 +175,7 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the same year as the original,
   /// but the month and day are set to January 1st, with hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get startOfCentury {
-    return _withSameZone(year - year % TimePlusConsts.yearsInCentury, 1, 1);
+    return withSameUtcFlag(year - year % TimePlusConsts.yearsInCentury, 1, 1);
   }
 
   /// Returns a [DateTime] representing the end of the current century.
@@ -171,31 +183,11 @@ extension DateTimeBoundariesExtensions on DateTime {
   /// The returned [DateTime] has the year incremented by one hundred,
   /// with the month and day set to January 1st, and hours, minutes, seconds, milliseconds, and microseconds set to zero.
   DateTime get endOfCentury {
-    return _withSameZone(
+    return withSameUtcFlag(
         year -
             year % TimePlusConsts.yearsInCentury +
             TimePlusConsts.yearsInCentury,
         1,
         1);
-  }
-
-  /// Creates a [DateTime] object with the same time zone as the original.
-  ///
-  /// The [year], [month], [day], [hour], [minute], [second], [millisecond], and [microsecond]
-  /// parameters are used to construct the new [DateTime] object. If the original [DateTime] is in UTC,
-  /// the new [DateTime] will also be in UTC.
-  DateTime _withSameZone(int year,
-      [int month = 1,
-      int day = 1,
-      int hour = 0,
-      int minute = 0,
-      int second = 0,
-      int millisecond = 0,
-      int microsecond = 0]) {
-    return isUtc
-        ? DateTime.utc(
-            year, month, day, hour, minute, second, millisecond, microsecond)
-        : DateTime(
-            year, month, day, hour, minute, second, millisecond, microsecond);
   }
 }

--- a/lib/src/date_time/date_time.dart
+++ b/lib/src/date_time/date_time.dart
@@ -1,4 +1,5 @@
 export 'add/add.dart';
+export 'subtract/subtract.dart';
 export 'boundaries.dart';
 export 'is_same.dart';
 export 'leap_year.dart';

--- a/lib/src/date_time/next.dart
+++ b/lib/src/date_time/next.dart
@@ -1,3 +1,5 @@
+import 'utc_flag.dart';
+
 extension DateTimeNextExtensions on DateTime {
   /// Returns the next occurrence of the given [weekday] and optional time.
   /// - Skips the current instance even if it matches.
@@ -13,7 +15,7 @@ extension DateTimeNextExtensions on DateTime {
     final daysToAdd = (weekday - this.weekday + 7) % 7;
     var nextDate = add(Duration(days: daysToAdd == 0 ? 7 : daysToAdd));
 
-    final result = _withSameZone(
+    final result = withSameUtcFlag(
       nextDate.year,
       nextDate.month,
       nextDate.day,
@@ -36,7 +38,7 @@ extension DateTimeNextExtensions on DateTime {
     int millisecond = 0,
     int microsecond = 0,
   }) {
-    final today = _withSameZone(
+    final today = withSameUtcFlag(
       year,
       month,
       day,
@@ -48,25 +50,5 @@ extension DateTimeNextExtensions on DateTime {
     );
 
     return today.isAfter(this) ? today : today.add(const Duration(days: 1));
-  }
-
-  /// Creates a [DateTime] object with the same time zone as the original.
-  ///
-  /// The [year], [month], [day], [hour], [minute], [second], [millisecond], and [microsecond]
-  /// parameters are used to construct the new [DateTime] object. If the original [DateTime] is in UTC,
-  /// the new [DateTime] will also be in UTC.
-  DateTime _withSameZone(int year,
-      [int month = 1,
-      int day = 1,
-      int hour = 0,
-      int minute = 0,
-      int second = 0,
-      int millisecond = 0,
-      int microsecond = 0]) {
-    return isUtc
-        ? DateTime.utc(
-            year, month, day, hour, minute, second, millisecond, microsecond)
-        : DateTime(
-            year, month, day, hour, minute, second, millisecond, microsecond);
   }
 }

--- a/lib/src/date_time/subtract/durations.dart
+++ b/lib/src/date_time/subtract/durations.dart
@@ -1,4 +1,5 @@
 import '../../consts.dart';
+import '../utc_flag.dart';
 
 /// Extension on [DateTime] to subtract various durations.
 extension DateTimeSubtractDurationsExtensions on DateTime {
@@ -54,7 +55,7 @@ extension DateTimeSubtractDurationsExtensions on DateTime {
   /// DateTime past = now.subtractDays(7);
   /// ```
   DateTime subtractDays(int days) {
-    return subtract(Duration(days: days));
+    return copyWithSameUtcFlag(day: day - days);
   }
 
   /// Returns a new [DateTime] with the specified number of [weeks] subtracted.
@@ -65,7 +66,7 @@ extension DateTimeSubtractDurationsExtensions on DateTime {
   /// DateTime past = now.subtractWeeks(3);
   /// ```
   DateTime subtractWeeks(int weeks) {
-    return subtract(Duration(days: weeks * TimePlusConsts.daysInWeek));
+    return subtractDays(weeks * TimePlusConsts.daysInWeek);
   }
 
   /// Returns a new [DateTime] with one millisecond subtracted.

--- a/lib/src/date_time/subtract/durations.dart
+++ b/lib/src/date_time/subtract/durations.dart
@@ -1,0 +1,88 @@
+import '../../consts.dart';
+
+/// Extension on [DateTime] to subtract various durations.
+extension DateTimeSubtractDurationsExtensions on DateTime {
+  /// Returns a new [DateTime] with the specified number of [milliseconds] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractMilliseconds(500);
+  /// ```
+  DateTime subtractMilliseconds(int milliseconds) {
+    return subtract(Duration(milliseconds: milliseconds));
+  }
+
+  /// Returns a new [DateTime] with the specified number of [seconds] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractSeconds(30);
+  /// ```
+  DateTime subtractSeconds(int seconds) {
+    return subtract(Duration(seconds: seconds));
+  }
+
+  /// Returns a new [DateTime] with the specified number of [minutes] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractMinutes(15);
+  /// ```
+  DateTime subtractMinutes(int minutes) {
+    return subtract(Duration(minutes: minutes));
+  }
+
+  /// Returns a new [DateTime] with the specified number of [hours] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractHours(2);
+  /// ```
+  DateTime subtractHours(int hours) {
+    return subtract(Duration(hours: hours));
+  }
+
+  /// Returns a new [DateTime] with the specified number of [days] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractDays(7);
+  /// ```
+  DateTime subtractDays(int days) {
+    return subtract(Duration(days: days));
+  }
+
+  /// Returns a new [DateTime] with the specified number of [weeks] subtracted.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime.now();
+  /// DateTime past = now.subtractWeeks(3);
+  /// ```
+  DateTime subtractWeeks(int weeks) {
+    return subtract(Duration(days: weeks * TimePlusConsts.daysInWeek));
+  }
+
+  /// Returns a new [DateTime] with one millisecond subtracted.
+  DateTime get subtractMillisecond => subtractMilliseconds(1);
+
+  /// Returns a new [DateTime] with one second subtracted.
+  DateTime get subtractSecond => subtractSeconds(1);
+
+  /// Returns a new [DateTime] with one minute subtracted.
+  DateTime get subtractMinute => subtractMinutes(1);
+
+  /// Returns a new [DateTime] with one hour subtracted.
+  DateTime get subtractHour => subtractHours(1);
+
+  /// Returns a new [DateTime] with one day subtracted.
+  DateTime get subtractDay => subtractDays(1);
+
+  /// Returns a new [DateTime] with one week subtracted.
+  DateTime get subtractWeek => subtractWeeks(1);
+}

--- a/lib/src/date_time/subtract/durations.dart
+++ b/lib/src/date_time/subtract/durations.dart
@@ -49,10 +49,14 @@ extension DateTimeSubtractDurationsExtensions on DateTime {
 
   /// Returns a new [DateTime] with the specified number of [days] subtracted.
   ///
+  /// This method preserves the exact time of day and is not equivalent to subtracting
+  /// 24 hours. It will keep the same time but move to the specified number of
+  /// days in the past, which is important for daylight saving time handling.
+  ///
   /// Example:
   /// ```dart
   /// DateTime now = DateTime.now();
-  /// DateTime past = now.subtractDays(7);
+  /// DateTime past = now.subtractDays(7); // Same time, 7 days earlier
   /// ```
   DateTime subtractDays(int days) {
     return copyWithSameUtcFlag(day: day - days);
@@ -60,10 +64,14 @@ extension DateTimeSubtractDurationsExtensions on DateTime {
 
   /// Returns a new [DateTime] with the specified number of [weeks] subtracted.
   ///
+  /// This method preserves the exact time of day and is not equivalent to subtracting
+  /// 168 hours (7 × 24). It will keep the same time but move to the specified
+  /// number of weeks in the past, which is important for daylight saving time handling.
+  ///
   /// Example:
   /// ```dart
   /// DateTime now = DateTime.now();
-  /// DateTime past = now.subtractWeeks(3);
+  /// DateTime past = now.subtractWeeks(3); // Same time, 3 weeks earlier
   /// ```
   DateTime subtractWeeks(int weeks) {
     return subtractDays(weeks * TimePlusConsts.daysInWeek);

--- a/lib/src/date_time/subtract/extending_years.dart
+++ b/lib/src/date_time/subtract/extending_years.dart
@@ -1,0 +1,59 @@
+import '../../consts.dart';
+import 'month_and_year.dart';
+
+/// Extension on [DateTime] to subtract decades and centuries, with proper handling of year overflow.
+extension DateTimeSubtractExtendingYearsExtension on DateTime {
+  /// Returns a new [DateTime] with the specified number of [decades] subtracted.
+  ///
+  /// This method calculates the total number of years by multiplying the
+  /// given decades by the number of years in a decade, which is 10. It then subtracts these years from the current
+  /// [DateTime] instance.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2024, 5, 20);
+  /// DateTime past = now.subtractDecades(3); // May 20, 1994
+  /// ```
+  DateTime subtractDecades(int decades) {
+    return subtractYears(decades * TimePlusConsts.yearsInDecade);
+  }
+
+  /// Returns a new [DateTime] with the specified number of [centuries] subtracted.
+  ///
+  /// This method calculates the total number of decades by multiplying the
+  /// given centuries by the number of decades in a century, which is 10. It then subtracts these decades from the
+  /// current [DateTime] instance.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2024, 5, 20);
+  /// DateTime past = now.subtractCenturies(1); // May 20, 1924
+  /// ```
+  DateTime subtractCenturies(int centuries) {
+    return subtractDecades(centuries * TimePlusConsts.decadesInCentury);
+  }
+
+  /// Shortcut to subtract exactly one decade from the current [DateTime].
+  ///
+  /// This getter is a convenient way to subtract a single decade without
+  /// specifying the number of decades explicitly.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2024, 5, 20);
+  /// DateTime past = now.subtractDecade; // May 20, 2014
+  /// ```
+  DateTime get subtractDecade => subtractDecades(1);
+
+  /// Shortcut to subtract exactly one century from the current [DateTime].
+  ///
+  /// This getter is a convenient way to subtract a single century without
+  /// specifying the number of centuries explicitly.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2024, 5, 20);
+  /// DateTime past = now.subtractCentury; // May 20, 1924
+  /// ```
+  DateTime get subtractCentury => subtractCenturies(1);
+}

--- a/lib/src/date_time/subtract/month_and_year.dart
+++ b/lib/src/date_time/subtract/month_and_year.dart
@@ -1,0 +1,75 @@
+import '../utc_flag.dart';
+import '../../consts.dart';
+
+/// Extension on [DateTime] to subtract months and years, with proper handling of month overflow and leap years.
+extension DateTimeSubtractMonthsAndYearsExtension on DateTime {
+  /// Returns a new [DateTime] with the specified number of [months] subtracted.
+  ///
+  /// The day of the month is clamped to the last valid day of the resulting month.
+  /// For example, subtracting 1 month from March 31 will result in February 28 (or 29 in a leap year).
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2023, 3, 31);
+  /// DateTime past = now.subtractMonths(1); // February 28 or 29
+  /// ```
+  DateTime subtractMonths(int months) {
+    final totalMonths =
+        year * TimePlusConsts.monthsInYear + (month - 1) - months;
+    final newYear = totalMonths ~/ TimePlusConsts.monthsInYear;
+    final newMonth = (totalMonths % TimePlusConsts.monthsInYear) + 1;
+
+    return _createDateTimeWithClampedDay(newYear, newMonth);
+  }
+
+  /// Returns a new [DateTime] with the specified number of [years] subtracted.
+  ///
+  /// The day of the month is clamped to the last valid day of the resulting month.
+  /// For example, subtracting 1 year from February 29 will result in February 28 if the resulting year is not a leap year.
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2021, 2, 28);
+  /// DateTime past = now.subtractYears(1); // February 28, 2020
+  /// ```
+  DateTime subtractYears(int years) {
+    final newYear = year - years;
+    final newMonth = month;
+
+    return _createDateTimeWithClampedDay(newYear, newMonth);
+  }
+
+  /// Shortcut to subtract exactly one month from the current [DateTime].
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2023, 3, 31);
+  /// DateTime past = now.subtractMonth; // February 28 or 29
+  /// ```
+  DateTime get subtractMonth => subtractMonths(1);
+
+  /// Shortcut to subtract exactly one year from the current [DateTime].
+  ///
+  /// Example:
+  /// ```dart
+  /// DateTime now = DateTime(2021, 2, 28);
+  /// DateTime past = now.subtractYear; // February 28, 2020
+  /// ```
+  DateTime get subtractYear => subtractYears(1);
+
+  /// Creates a new [DateTime] with the specified [newYear] and [newMonth],
+  /// clamping the day to the last valid day of the month.
+  ///
+  /// This ensures that the resulting [DateTime] is always valid, even if the
+  /// original day does not exist in the new month (e.g., February 30).
+  DateTime _createDateTimeWithClampedDay(int newYear, int newMonth) {
+    final lastDayOfMonth = DateTime(newYear, newMonth + 1, 0).day;
+    final newDay = day.clamp(1, lastDayOfMonth);
+    // preserve the original time-of-day and UTC/local flag:
+    return copyWithSameUtcFlag(
+      year: newYear,
+      month: newMonth,
+      day: newDay,
+    );
+  }
+}

--- a/lib/src/date_time/subtract/subtract.dart
+++ b/lib/src/date_time/subtract/subtract.dart
@@ -1,0 +1,1 @@
+export 'durations.dart';

--- a/lib/src/date_time/subtract/subtract.dart
+++ b/lib/src/date_time/subtract/subtract.dart
@@ -1,1 +1,2 @@
 export 'durations.dart';
+export 'month_and_year.dart';

--- a/lib/src/date_time/subtract/subtract.dart
+++ b/lib/src/date_time/subtract/subtract.dart
@@ -1,2 +1,3 @@
 export 'durations.dart';
 export 'month_and_year.dart';
+export 'extending_years.dart';

--- a/lib/src/date_time/utc_flag.dart
+++ b/lib/src/date_time/utc_flag.dart
@@ -1,0 +1,48 @@
+extension DateTimeUtcFlagExtensions on DateTime {
+  /// Creates a [DateTime] object with the same UTC flag as the original.
+  ///
+  /// Constructs a new [DateTime] object using the provided [year], [month], [day], [hour], [minute],
+  /// [second], [millisecond], and [microsecond] parameters. The new [DateTime] will have the same
+  /// UTC flag as the original: if the original [DateTime] is in UTC, the new [DateTime] will also be in UTC.
+  DateTime withSameUtcFlag(int year,
+      [int month = 1,
+      int day = 1,
+      int hour = 0,
+      int minute = 0,
+      int second = 0,
+      int millisecond = 0,
+      int microsecond = 0]) {
+    return isUtc
+        ? DateTime.utc(
+            year, month, day, hour, minute, second, millisecond, microsecond)
+        : DateTime(
+            year, month, day, hour, minute, second, millisecond, microsecond);
+  }
+
+  /// Creates a new [DateTime] object with the same UTC flag as the original.
+  ///
+  /// Constructs a new [DateTime] object using the provided parameters, defaulting to the values
+  /// of the original [DateTime] if not specified. The new [DateTime] will have the same UTC flag
+  /// as the original: if the original [DateTime] is in UTC, the new [DateTime] will also be in UTC.
+  DateTime copyWithSameUtcFlag({
+    int? year,
+    int? month,
+    int? day,
+    int? hour,
+    int? minute,
+    int? second,
+    int? millisecond,
+    int? microsecond,
+  }) {
+    return withSameUtcFlag(
+      year ?? this.year,
+      month ?? this.month,
+      day ?? this.day,
+      hour ?? this.hour,
+      minute ?? this.minute,
+      second ?? this.second,
+      millisecond ?? this.millisecond,
+      microsecond ?? this.microsecond,
+    );
+  }
+}

--- a/lib/time_plus.dart
+++ b/lib/time_plus.dart
@@ -11,6 +11,6 @@
 ///
 /// Designed with simplicity and clarity in mind.
 /// No dependencies. Just useful time extensions.
-library;
+library time_plus;
 
 export 'src/time_plus.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - date-time
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
 

--- a/test/date_time/subtract/durations_test.dart
+++ b/test/date_time/subtract/durations_test.dart
@@ -1,0 +1,258 @@
+import 'package:test/test.dart';
+import 'package:time_plus/time_plus.dart';
+
+void main() {
+  group('DateTimeSubtractDurationsExtensions - Explicit Methods', () {
+    test('subtractMilliseconds returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500);
+      final DateTime result = now.subtractMilliseconds(200);
+      expect(result, DateTime(2024, 4, 20, 10, 30, 45, 300));
+    });
+
+    test('subtractMilliseconds with large value rolls back seconds', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500);
+      final DateTime result = now.subtractMilliseconds(1500);
+      expect(result, DateTime(2024, 4, 20, 10, 30, 44, 0));
+    });
+
+    test('subtractSeconds returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now.subtractSeconds(15);
+      expect(result, DateTime(2024, 4, 20, 10, 30, 30));
+    });
+
+    test('subtractSeconds with large value rolls back minutes', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now.subtractSeconds(75);
+      expect(result, DateTime(2024, 4, 20, 10, 29, 30));
+    });
+
+    test('subtractMinutes returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30);
+      final DateTime result = now.subtractMinutes(15);
+      expect(result, DateTime(2024, 4, 20, 10, 15));
+    });
+
+    test('subtractMinutes with large value rolls back hours', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30);
+      final DateTime result = now.subtractMinutes(75);
+      expect(result, DateTime(2024, 4, 20, 9, 15));
+    });
+
+    test('subtractHours returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20, 10);
+      final DateTime result = now.subtractHours(5);
+      expect(result, DateTime(2024, 4, 20, 5));
+    });
+
+    test('subtractHours with large value rolls back days', () {
+      final DateTime now = DateTime(2024, 4, 20, 10);
+      final DateTime result = now.subtractHours(25);
+      expect(result, DateTime(2024, 4, 19, 9));
+    });
+
+    test('subtractDays returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractDays(5);
+      expect(result, DateTime(2024, 4, 15));
+    });
+
+    test('subtractDays in UTC always rolls back N×24h', () {
+      final now = DateTime(2024, 4, 20, 0, 0);
+      final result = now.subtractDays(35);
+      expect(result, DateTime(2024, 3, 16, 0, 0));
+    });
+
+    test('subtractDays', () {
+      final now = DateTime(2024, 4, 20);
+      final result = now.subtractDays(35);
+      expect(result, DateTime(2024, 3, 16));
+    });
+
+    test('subtractWeeks returns correct DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractWeeks(2);
+      expect(result, DateTime(2024, 4, 6));
+    });
+
+    test('subtractWeeks with large value rolls back months and years', () {
+      final DateTime now = DateTime(2024, 1, 20);
+      final DateTime result = now.subtractWeeks(8);
+      expect(result, DateTime(2023, 11, 25));
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Edge Cases', () {
+    test('subtractDays handles month boundaries correctly', () {
+      final DateTime start = DateTime(2024, 5, 1);
+      final DateTime result = start.subtractDays(1);
+      expect(result, DateTime(2024, 4, 30));
+    });
+
+    test('subtractDays handles leap year correctly', () {
+      final DateTime start = DateTime(2024, 3, 1); // 2024 is a leap year
+      final DateTime result = start.subtractDays(1);
+      expect(result, DateTime(2024, 2, 29));
+    });
+
+    test('subtractDays handles non-leap year correctly', () {
+      final DateTime start = DateTime(2023, 3, 1); // 2023 is not a leap year
+      final DateTime result = start.subtractDays(1);
+      expect(result, DateTime(2023, 2, 28));
+    });
+
+    test('subtractDays handles year boundaries correctly', () {
+      final DateTime start = DateTime(2024, 1, 1);
+      final DateTime result = start.subtractDays(1);
+      expect(result, DateTime(2023, 12, 31));
+    });
+
+    test('subtractMilliseconds with zero value returns same DateTime', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500);
+      final DateTime result = now.subtractMilliseconds(0);
+      expect(result, now);
+    });
+
+    test('subtractMilliseconds preserves microseconds', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500, 250);
+      final DateTime result = now.subtractMilliseconds(200);
+      expect(result, DateTime(2024, 4, 20, 10, 30, 45, 300, 250));
+    });
+
+    test('subtractMilliseconds preserves timezone', () {
+      final DateTime utcNow = DateTime.utc(2024, 4, 20, 10, 30);
+      final DateTime result = utcNow.subtractMilliseconds(500);
+      expect(result.isUtc, true);
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Getter Methods', () {
+    test('subtractMillisecond works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500);
+      final DateTime result = now.subtractMillisecond;
+      expect(result, DateTime(2024, 4, 20, 10, 30, 45, 499));
+    });
+
+    test('subtractSecond works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now.subtractSecond;
+      expect(result, DateTime(2024, 4, 20, 10, 30, 44));
+    });
+
+    test('subtractMinute works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30);
+      final DateTime result = now.subtractMinute;
+      expect(result, DateTime(2024, 4, 20, 10, 29));
+    });
+
+    test('subtractHour works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10);
+      final DateTime result = now.subtractHour;
+      expect(result, DateTime(2024, 4, 20, 9));
+    });
+
+    test('subtractDay works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractDay;
+      expect(result, DateTime(2024, 4, 19));
+    });
+
+    test('subtractWeek works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractWeek;
+      expect(result, DateTime(2024, 4, 13));
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Chaining Methods', () {
+    test('chaining multiple subtractions works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now
+          .subtractDays(1)
+          .subtractHours(2)
+          .subtractMinutes(15)
+          .subtractSeconds(30);
+      expect(result, DateTime(2024, 4, 19, 8, 15, 15));
+    });
+
+    test('chaining getter methods works correctly', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now.subtractDay.subtractHour.subtractMinute;
+      expect(result, DateTime(2024, 4, 19, 9, 29, 45));
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Negative Values', () {
+    test('subtractMilliseconds with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45, 500);
+      final DateTime result = now.subtractMilliseconds(-200);
+      expect(result, DateTime(2024, 4, 20, 10, 30, 45, 700));
+    });
+
+    test('subtractSeconds with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30, 45);
+      final DateTime result = now.subtractSeconds(-15);
+      expect(result, DateTime(2024, 4, 20, 10, 31, 0));
+    });
+
+    test('subtractMinutes with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20, 10, 30);
+      final DateTime result = now.subtractMinutes(-15);
+      expect(result, DateTime(2024, 4, 20, 10, 45));
+    });
+
+    test('subtractHours with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20, 10);
+      final DateTime result = now.subtractHours(-5);
+      expect(result, DateTime(2024, 4, 20, 15));
+    });
+
+    test('subtractDays with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractDays(-5);
+      expect(result, DateTime(2024, 4, 25));
+    });
+
+    test('subtractWeeks with negative value adds time', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractWeeks(-2);
+      expect(result, DateTime(2024, 5, 4));
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Large Values', () {
+    test('subtractDays with very large value', () {
+      final DateTime now = DateTime(2024, 4, 20);
+      final DateTime result = now.subtractDays(1000);
+      expect(result, DateTime(2021, 7, 25));
+    });
+
+    test('subtractWeeks with very large value', () {
+      final DateTime now = DateTime.utc(2024, 4, 20);
+      final DateTime result = now.subtractWeek;
+      expect(result, DateTime.utc(2024, 4, 13));
+      final result2 = result.subtractWeeks(100);
+      final diff = result2.difference(result);
+      expect(diff.inDays, -100 * 7);
+    });
+  });
+
+  group('DateTimeSubtractDurationsExtensions - Time Components', () {
+    test('all time components are preserved when subtracting days', () {
+      final DateTime now = DateTime(2024, 4, 20, 15, 30, 45, 500, 250);
+      final DateTime result = now.subtractDays(5);
+      expect(result, DateTime(2024, 4, 15, 15, 30, 45, 500, 250));
+    });
+
+    test('time zone is preserved', () {
+      final DateTime localNow = DateTime(2024, 4, 20, 10);
+      final DateTime utcNow = DateTime.utc(2024, 4, 20, 10);
+
+      final DateTime localResult = localNow.subtractDays(5);
+      final DateTime utcResult = utcNow.subtractDays(5);
+
+      expect(localResult.isUtc, false);
+      expect(utcResult.isUtc, true);
+    });
+  });
+}

--- a/test/date_time/subtract/extending_years_test.dart
+++ b/test/date_time/subtract/extending_years_test.dart
@@ -1,0 +1,476 @@
+import 'package:test/test.dart';
+import 'package:time_plus/time_plus.dart';
+
+void main() {
+  group('DateTimeSubtractExtendingYearsExtension - Basic Decade Subtraction',
+      () {
+    test('subtractDecades returns correct DateTime for simple case', () {
+      final DateTime now = DateTime(2024, 6, 15, 10, 30, 45);
+      final DateTime result = now.subtractDecades(2);
+      expect(result, DateTime(2004, 6, 15, 10, 30, 45));
+    });
+
+    test('subtractDecades with single decade', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractDecades(1);
+      expect(result, DateTime(2014, 3, 15));
+    });
+
+    test('subtractDecades preserves time components', () {
+      final DateTime now = DateTime(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = now.subtractDecades(3);
+      expect(result, DateTime(1994, 6, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractDecades with zero decades returns same DateTime', () {
+      final DateTime now = DateTime(2024, 4, 15, 10, 30);
+      final DateTime result = now.subtractDecades(0);
+      expect(result, now);
+    });
+
+    test('subtractDecade getter works correctly', () {
+      final DateTime now = DateTime(2024, 5, 15);
+      final DateTime result = now.subtractDecade;
+      expect(result, DateTime(2014, 5, 15));
+    });
+
+    test('subtractDecades preserves month and day', () {
+      final DateTime now = DateTime(2024, 12, 25, 18, 45);
+      final DateTime result = now.subtractDecades(5);
+      expect(result, DateTime(1974, 12, 25, 18, 45));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Basic Century Subtraction',
+      () {
+    test('subtractCenturies returns correct DateTime for simple case', () {
+      final DateTime now = DateTime(2024, 6, 15, 10, 30, 45);
+      final DateTime result = now.subtractCenturies(2);
+      expect(result, DateTime(1824, 6, 15, 10, 30, 45));
+    });
+
+    test('subtractCenturies with single century', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractCenturies(1);
+      expect(result, DateTime(1924, 3, 15));
+    });
+
+    test('subtractCenturies preserves time components', () {
+      final DateTime now = DateTime(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = now.subtractCenturies(3);
+      expect(result, DateTime(1724, 6, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractCenturies with zero centuries returns same DateTime', () {
+      final DateTime now = DateTime(2024, 4, 15, 10, 30);
+      final DateTime result = now.subtractCenturies(0);
+      expect(result, now);
+    });
+
+    test('subtractCentury getter works correctly', () {
+      final DateTime now = DateTime(2024, 5, 15);
+      final DateTime result = now.subtractCentury;
+      expect(result, DateTime(1924, 5, 15));
+    });
+
+    test('subtractCenturies preserves month and day', () {
+      final DateTime now = DateTime(2024, 12, 25, 18, 45);
+      final DateTime result = now.subtractCenturies(4);
+      expect(result, DateTime(1624, 12, 25, 18, 45));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Leap Year Handling', () {
+    test('subtractDecades from leap day to non-leap year clamps to Feb 28', () {
+      final DateTime now = DateTime(2024, 2, 29, 12, 30); // leap year
+      final DateTime result = now.subtractDecades(1); // goes to 2014
+      expect(
+          result,
+          DateTime(
+              2014, 2, 28, 12, 30)); // 2014 is not leap year, clamped to Feb 28
+    });
+
+    test('subtractDecades from leap day to another leap year preserves Feb 29',
+        () {
+      final DateTime now = DateTime(2024, 2, 29, 15, 45); // leap year
+      final DateTime result = now.subtractDecades(1); // goes to 2014 (not leap)
+      expect(result, DateTime(2014, 2, 28, 15, 45)); // clamped to Feb 28
+    });
+
+    test('subtractDecades preserves leap day when target is leap year', () {
+      final DateTime now = DateTime(2020, 2, 29, 9, 15); // leap year
+      final DateTime result =
+          now.subtractDecades(2); // goes to 2000 (leap year)
+      expect(result, DateTime(2000, 2, 29, 9, 15)); // Feb 29 preserved
+    });
+
+    test('subtractCenturies from leap day to century non-leap year', () {
+      final DateTime now = DateTime(2000, 2, 29, 16, 20); // century leap year
+      final DateTime result = now.subtractCenturies(1); // goes to 1900
+      expect(result, DateTime(1900, 2, 28, 16, 20)); // 1900 was not a leap year
+    });
+
+    test('subtractCenturies handles century leap year correctly', () {
+      final DateTime now =
+          DateTime(2400, 2, 29, 11, 45); // future century leap year
+      final DateTime result = now.subtractCenturies(1); // goes to 2300
+      expect(result, DateTime(2300, 2, 28, 11, 45)); // 2300 is not a leap year
+    });
+
+    test('subtractDecades multiple leap year interactions', () {
+      final DateTime now = DateTime(2024, 2, 29, 14, 30); // leap year
+      final DateTime result = now.subtractDecades(3); // goes to 1994 (not leap)
+      expect(result, DateTime(1994, 2, 28, 14, 30)); // clamped to Feb 28
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Large Time Spans', () {
+    test('subtractDecades with very large value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractDecades(20); // 200 years
+      expect(result, DateTime(1824, 6, 15));
+    });
+
+    test('subtractCenturies spanning multiple millennia', () {
+      final DateTime now = DateTime(2024, 7, 4, 12, 0);
+      final DateTime result = now.subtractCenturies(10); // 1000 years
+      expect(result, DateTime(1024, 7, 4, 12, 0));
+    });
+
+    test('subtractDecades going back to ancient times', () {
+      final DateTime now = DateTime(2024, 12, 25);
+      final DateTime result = now.subtractDecades(202); // 2020 years
+      expect(result, DateTime(4, 12, 25));
+    });
+
+    test('subtractCenturies with maximum span', () {
+      final DateTime now = DateTime(2024, 1, 1, 0, 0);
+      final DateTime result = now.subtractCenturies(20); // 2000 years
+      expect(result, DateTime(24, 1, 1, 0, 0));
+    });
+
+    test('subtractDecades to year 1', () {
+      final DateTime now = DateTime(2024, 8, 15);
+      final DateTime result = now.subtractDecades(202); // 2020 years
+      expect(result, DateTime(4, 8, 15));
+    });
+  });
+
+  group(
+      'DateTimeSubtractExtendingYearsExtension - UTC and Timezone Preservation',
+      () {
+    test('subtractDecades preserves UTC flag when true', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 10, 30);
+      final DateTime result = utcNow.subtractDecades(3);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1994, 5, 15, 10, 30));
+    });
+
+    test('subtractCenturies preserves UTC flag when true', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 10, 30);
+      final DateTime result = utcNow.subtractCenturies(2);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1824, 5, 15, 10, 30));
+    });
+
+    test('subtractDecades preserves local timezone when false', () {
+      final DateTime localNow = DateTime(2024, 5, 15, 10, 30);
+      final DateTime result = localNow.subtractDecades(2);
+      expect(result.isUtc, false);
+      expect(result, DateTime(2004, 5, 15, 10, 30));
+    });
+
+    test('subtractCenturies preserves local timezone when false', () {
+      final DateTime localNow = DateTime(2024, 5, 15, 10, 30);
+      final DateTime result = localNow.subtractCenturies(1);
+      expect(result.isUtc, false);
+      expect(result, DateTime(1924, 5, 15, 10, 30));
+    });
+
+    test('subtractDecade getter preserves UTC flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15);
+      final DateTime result = utcNow.subtractDecade;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2014, 5, 15));
+    });
+
+    test('subtractCentury getter preserves UTC flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15);
+      final DateTime result = utcNow.subtractCentury;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1924, 5, 15));
+    });
+
+    test('subtractDecades UTC with leap day clamping', () {
+      final DateTime utcNow = DateTime.utc(2024, 2, 29, 14, 30, 45);
+      final DateTime result = utcNow.subtractDecades(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2014, 2, 28, 14, 30, 45));
+    });
+
+    test('subtractCenturies preserves exact UTC time components', () {
+      final DateTime utcNow = DateTime.utc(2024, 8, 15, 23, 59, 59, 999, 999);
+      final DateTime result = utcNow.subtractCenturies(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1924, 8, 15, 23, 59, 59, 999, 999));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Negative Values', () {
+    test('subtractDecades with negative value adds decades', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractDecades(-5);
+      expect(result, DateTime(2074, 3, 15));
+    });
+
+    test('subtractCenturies with negative value adds centuries', () {
+      final DateTime now = DateTime(2024, 6, 20);
+      final DateTime result = now.subtractCenturies(-2);
+      expect(result, DateTime(2224, 6, 20));
+    });
+
+    test('subtractDecades with negative value and leap day handling', () {
+      final DateTime now = DateTime(2023, 2, 28); // non-leap year
+      final DateTime result =
+          now.subtractDecades(-1); // equivalent to adding 1 decade
+      expect(result, DateTime(2033, 2, 28)); // Feb 28 preserved
+    });
+
+    test('subtractCenturies with negative value requires day clamping', () {
+      final DateTime now = DateTime(1923, 2, 28);
+      final DateTime result =
+          now.subtractCenturies(-1); // add 1 century to reach 2023
+      expect(result, DateTime(2023, 2, 28)); // should stay Feb 28
+    });
+
+    test('subtractDecades with large negative value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractDecades(-10); // 100 years into future
+      expect(result, DateTime(2124, 6, 15));
+    });
+
+    test('subtractCenturies with large negative value', () {
+      final DateTime now = DateTime(2024, 9, 30);
+      final DateTime result =
+          now.subtractCenturies(-5); // 500 years into future
+      expect(result, DateTime(2524, 9, 30));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Complex Scenarios', () {
+    test('subtractDecades multiple times in sequence', () {
+      final DateTime now = DateTime(2024, 7, 15, 16, 30);
+      final DateTime result = now
+          .subtractDecades(1) // 2014
+          .subtractDecades(2) // 1994
+          .subtractDecades(3); // 1964
+      expect(result, DateTime(1964, 7, 15, 16, 30));
+    });
+
+    test('subtractCenturies multiple times in sequence', () {
+      final DateTime now = DateTime(2024, 4, 10, 8, 45);
+      final DateTime result = now
+          .subtractCenturies(1) // 1924
+          .subtractCenturies(2) // 1724
+          .subtractCenturies(1); // 1624
+      expect(result, DateTime(1624, 4, 10, 8, 45));
+    });
+
+    test('mixed subtractDecades and subtractCenturies operations', () {
+      final DateTime now = DateTime(2024, 12, 31, 23, 59);
+      final DateTime result = now
+          .subtractCenturies(1) // 1924
+          .subtractDecades(2) // 1904
+          .subtractDecades(1); // 1894
+      expect(result, DateTime(1894, 12, 31, 23, 59));
+    });
+
+    test('subtractDecades chained with leap day handling', () {
+      final DateTime now = DateTime(2024, 2, 29, 12, 0); // leap day
+      final DateTime result = now
+          .subtractDecades(1) // 2014, Feb 28 (clamped)
+          .subtractDecades(1) // 2004, Feb 28
+          .subtractDecades(1); // 1994, Feb 28
+      expect(result, DateTime(1994, 2, 28, 12, 0));
+    });
+
+    test('subtractCenturies preserves milliseconds and microseconds', () {
+      final DateTime now = DateTime(2024, 9, 21, 14, 35, 45, 123, 456);
+      final DateTime result = now.subtractCenturies(2);
+      expect(result, DateTime(1824, 9, 21, 14, 35, 45, 123, 456));
+    });
+
+    test('subtractDecades alternating positive and negative', () {
+      final DateTime now = DateTime(2024, 4, 10);
+      final DateTime result = now
+          .subtractDecades(5) // 1974
+          .subtractDecades(-2) // 1994
+          .subtractDecades(1); // 1984
+      expect(result, DateTime(1984, 4, 10));
+    });
+
+    test('getter methods chained together', () {
+      final DateTime now = DateTime(2024, 6, 15, 12, 30);
+      final DateTime result = now.subtractCentury.subtractDecade;
+      expect(result, DateTime(1914, 6, 15, 12, 30));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Historical Periods', () {
+    test('subtractCenturies to different historical eras', () {
+      final DateTime now = DateTime(2024, 7, 4, 12, 0);
+
+      // Different historical periods
+      expect(now.subtractCenturies(1),
+          DateTime(1924, 7, 4, 12, 0)); // 20th century
+      expect(now.subtractCenturies(2),
+          DateTime(1824, 7, 4, 12, 0)); // 19th century
+      expect(now.subtractCenturies(3),
+          DateTime(1724, 7, 4, 12, 0)); // 18th century
+      expect(now.subtractCenturies(10),
+          DateTime(1024, 7, 4, 12, 0)); // Medieval times
+    });
+
+    test('subtractDecades to various recent historical periods', () {
+      final DateTime now = DateTime(2024, 8, 15, 15, 30);
+
+      // Recent historical decades
+      expect(now.subtractDecades(1), DateTime(2014, 8, 15, 15, 30)); // 2010s
+      expect(now.subtractDecades(2), DateTime(2004, 8, 15, 15, 30)); // 2000s
+      expect(now.subtractDecades(3), DateTime(1994, 8, 15, 15, 30)); // 1990s
+      expect(now.subtractDecades(5), DateTime(1974, 8, 15, 15, 30)); // 1970s
+      expect(now.subtractDecades(10), DateTime(1924, 8, 15, 15, 30)); // 1920s
+    });
+
+    test('subtractCenturies handles century boundaries correctly', () {
+      final DateTime now = DateTime(2000, 1, 1, 0, 0); // Y2K
+      final DateTime result = now.subtractCenturies(1);
+      expect(result, DateTime(1900, 1, 1, 0, 0));
+    });
+
+    test('subtractDecades across century boundaries', () {
+      final DateTime now = DateTime(2003, 5, 20);
+      final DateTime result = now.subtractDecades(10); // 100 years
+      expect(result, DateTime(1903, 5, 20));
+    });
+
+    test('subtractCenturies with leap year considerations in history', () {
+      final DateTime now = DateTime(2000, 2, 29); // Y2K leap day
+      final DateTime result = now.subtractCenturies(1);
+      expect(result, DateTime(1900, 2, 28)); // 1900 was not a leap year
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Performance and Edge Cases',
+      () {
+    test('subtractDecades with very large value preserves precision', () {
+      final DateTime now = DateTime(2024, 11, 11, 11, 11, 11, 111, 111);
+      final DateTime result = now.subtractDecades(100); // 1000 years
+      expect(result, DateTime(1024, 11, 11, 11, 11, 11, 111, 111));
+    });
+
+    test('subtractCenturies with maximum precision preservation', () {
+      final DateTime now = DateTime(2024, 2, 29, 23, 59, 59, 999, 999);
+      final DateTime result = now.subtractCenturies(10); // 1000 years
+      expect(
+          result,
+          DateTime(1024, 2, 29, 23, 59, 59, 999,
+              999)); // 1024 is a leap year, Feb 29 preserved
+    });
+
+    test('subtractDecade getter with complex DateTime', () {
+      final DateTime now = DateTime(2024, 8, 31, 23, 59, 59, 999, 999);
+      final DateTime result = now.subtractDecade;
+      expect(result, DateTime(2014, 8, 31, 23, 59, 59, 999, 999));
+    });
+
+    test('subtractCentury getter with complex DateTime', () {
+      final DateTime now = DateTime(2024, 12, 31, 0, 0, 0, 1, 1);
+      final DateTime result = now.subtractCentury;
+      expect(result, DateTime(1924, 12, 31, 0, 0, 0, 1, 1));
+    });
+
+    test('subtractDecades creates new instance, not reference', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractDecades(0);
+      expect(result, now);
+      expect(identical(result, now), false);
+    });
+
+    test('subtractCenturies creates new instance, not reference', () {
+      final DateTime now = DateTime(2024, 3, 20);
+      final DateTime result = now.subtractCenturies(0);
+      expect(result, now);
+      expect(identical(result, now), false);
+    });
+
+    test('mixed operations on same DateTime base', () {
+      final DateTime base = DateTime(2024, 5, 15, 10, 30);
+
+      final result1 = base.subtractDecades(1);
+      final result2 = base.subtractCenturies(1);
+      final result3 = base.subtractDecade;
+      final result4 = base.subtractCentury;
+
+      expect(result1, DateTime(2014, 5, 15, 10, 30));
+      expect(result2, DateTime(1924, 5, 15, 10, 30));
+      expect(result3, DateTime(2014, 5, 15, 10, 30));
+      expect(result4, DateTime(1924, 5, 15, 10, 30));
+
+      // Original should be unchanged
+      expect(base, DateTime(2024, 5, 15, 10, 30));
+    });
+  });
+
+  group('DateTimeSubtractExtendingYearsExtension - Comprehensive UTC Tests',
+      () {
+    test('subtractDecades UTC with complex time preservation', () {
+      final DateTime utcNow = DateTime.utc(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = utcNow.subtractDecades(5);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1974, 6, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractCenturies UTC with leap day handling', () {
+      final DateTime utcNow = DateTime.utc(2000, 2, 29, 18, 45, 30);
+      final DateTime result = utcNow.subtractCenturies(1);
+      expect(result.isUtc, true);
+      expect(
+          result, DateTime.utc(1900, 2, 28, 18, 45, 30)); // 1900 not leap year
+    });
+
+    test('subtractDecades UTC chained operations preserve flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 12, 31, 23, 59, 59);
+      final DateTime result =
+          utcNow.subtractDecades(1).subtractDecades(2).subtractDecades(3);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1964, 12, 31, 23, 59, 59));
+    });
+
+    test('subtractCenturies UTC chained operations preserve flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 6, 15, 12, 0, 0);
+      final DateTime result = utcNow.subtractCenturies(2).subtractCenturies(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1724, 6, 15, 12, 0, 0));
+    });
+
+    test('getter methods preserve UTC with microsecond precision', () {
+      final DateTime utcNow = DateTime.utc(2024, 3, 15, 9, 30, 45, 123, 456);
+      final DateTime result1 = utcNow.subtractDecade;
+      final DateTime result2 = utcNow.subtractCentury;
+
+      expect(result1.isUtc, true);
+      expect(result2.isUtc, true);
+      expect(result1, DateTime.utc(2014, 3, 15, 9, 30, 45, 123, 456));
+      expect(result2, DateTime.utc(1924, 3, 15, 9, 30, 45, 123, 456));
+    });
+
+    test('subtractDecades UTC handles historical leap years correctly', () {
+      final DateTime utcNow = DateTime.utc(2000, 2, 29, 6, 15, 30);
+      final DateTime result = utcNow.subtractDecades(10);
+      expect(result.isUtc, true);
+      expect(
+          result, DateTime.utc(1900, 2, 28, 6, 15, 30)); // 1900 not leap year
+    });
+  });
+}

--- a/test/date_time/subtract/months_test.dart
+++ b/test/date_time/subtract/months_test.dart
@@ -1,0 +1,457 @@
+import 'package:test/test.dart';
+import 'package:time_plus/time_plus.dart';
+
+void main() {
+  group('DateTimeSubtractMonthsAndYearsExtension - Basic Month Subtraction',
+      () {
+    test('subtractMonths returns correct DateTime for simple case', () {
+      final DateTime now = DateTime(2024, 5, 15, 10, 30, 45);
+      final DateTime result = now.subtractMonths(2);
+      expect(result, DateTime(2024, 3, 15, 10, 30, 45));
+    });
+
+    test('subtractMonths with single month', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 2, 15));
+    });
+
+    test('subtractMonths preserves time components', () {
+      final DateTime now = DateTime(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 5, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractMonths with zero months returns same DateTime', () {
+      final DateTime now = DateTime(2024, 4, 15, 10, 30);
+      final DateTime result = now.subtractMonths(0);
+      expect(result, now);
+    });
+
+    test('subtractMonth getter works correctly', () {
+      final DateTime now = DateTime(2024, 5, 15);
+      final DateTime result = now.subtractMonth;
+      expect(result, DateTime(2024, 4, 15));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Year Boundary Crossing', () {
+    test('subtractMonths crosses year boundary', () {
+      final DateTime now = DateTime(2024, 2, 15);
+      final DateTime result = now.subtractMonths(3);
+      expect(result, DateTime(2023, 11, 15));
+    });
+
+    test('subtractMonths from January goes to previous year', () {
+      final DateTime now = DateTime(2024, 1, 15);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2023, 12, 15));
+    });
+
+    test('subtractMonths crosses multiple years', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractMonths(15);
+      expect(result, DateTime(2022, 12, 15));
+    });
+
+    test('subtractMonths with large value spans multiple years', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(30);
+      expect(result, DateTime(2021, 12, 15));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Day Clamping', () {
+    test(
+        'subtractMonths clamps day when target month has fewer days - March 31 to Feb',
+        () {
+      final DateTime now = DateTime(2024, 3, 31); // March 31
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 2, 29)); // 2024 is leap year
+    });
+
+    test(
+        'subtractMonths clamps day when target month has fewer days - March 31 to Feb (non-leap)',
+        () {
+      final DateTime now = DateTime(2023, 3, 31); // March 31
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2023, 2, 28)); // 2023 is not leap year
+    });
+
+    test('subtractMonths clamps day from May 31 to April 30', () {
+      final DateTime now = DateTime(2024, 5, 31);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 4, 30));
+    });
+
+    test('subtractMonths clamps day from July 31 to June 30', () {
+      final DateTime now = DateTime(2024, 7, 31);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 6, 30));
+    });
+
+    test('subtractMonths clamps day from August 31 to June 30', () {
+      final DateTime now = DateTime(2024, 8, 31);
+      final DateTime result = now.subtractMonths(2);
+      expect(result, DateTime(2024, 6, 30));
+    });
+
+    test('subtractMonths clamps day from October 31 to February 28', () {
+      final DateTime now = DateTime(2023, 10, 31);
+      final DateTime result = now.subtractMonths(8);
+      expect(result, DateTime(2023, 2, 28));
+    });
+
+    test(
+        'subtractMonths clamps day from December 31 to February 29 (leap year)',
+        () {
+      final DateTime now = DateTime(2024, 12, 31);
+      final DateTime result = now.subtractMonths(10);
+      expect(result, DateTime(2024, 2, 29));
+    });
+
+    test('subtractMonths preserves valid days when no clamping needed', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(2);
+      expect(result, DateTime(2024, 4, 15));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Leap Year Handling', () {
+    test('subtractMonths from March 1 to February 29 in leap year', () {
+      final DateTime now = DateTime(2024, 3, 1); // 2024 is leap year
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 2, 1));
+    });
+
+    test('subtractMonths from March 1 to February 28 in non-leap year', () {
+      final DateTime now = DateTime(2023, 3, 1); // 2023 is not leap year
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2023, 2, 1));
+    });
+
+    test('subtractMonths from February 29 to January 29', () {
+      final DateTime now = DateTime(2024, 2, 29); // leap year
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 1, 29));
+    });
+
+    test('subtractMonths from March 29 in leap year to February 29', () {
+      final DateTime now = DateTime(2024, 3, 29);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 2, 29));
+    });
+
+    test('subtractMonths from March 29 in non-leap year to February 28', () {
+      final DateTime now = DateTime(2023, 3, 29);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2023, 2, 28));
+    });
+
+    test('subtractMonths across leap year boundary', () {
+      final DateTime now = DateTime(2025, 2, 28); // 2025 is not leap year
+      final DateTime result = now.subtractMonths(12);
+      expect(result, DateTime(2024, 2, 28)); // 2024 is leap year
+    });
+  });
+
+  group(
+      'DateTimeSubtractMonthsAndYearsExtension - UTC and Timezone Preservation',
+      () {
+    test('subtractMonths preserves UTC flag when true', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 10, 30);
+      final DateTime result = utcNow.subtractMonths(2);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 3, 15, 10, 30));
+    });
+
+    test('subtractMonths preserves local timezone when false', () {
+      final DateTime localNow = DateTime(2024, 5, 15, 10, 30);
+      final DateTime result = localNow.subtractMonths(2);
+      expect(result.isUtc, false);
+      expect(result, DateTime(2024, 3, 15, 10, 30));
+    });
+
+    test('subtractMonth getter preserves UTC flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15);
+      final DateTime result = utcNow.subtractMonth;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 4, 15));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Comprehensive UTC Tests',
+      () {
+    test('subtractMonths with UTC DateTime preserves exact time components',
+        () {
+      final DateTime utcNow = DateTime.utc(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = utcNow.subtractMonths(3);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 3, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractMonths with UTC DateTime near midnight', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 0, 0, 0);
+      final DateTime result = utcNow.subtractMonths(2);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 3, 15, 0, 0, 0));
+    });
+
+    test('subtractMonths with UTC DateTime at end of day', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 23, 59, 59, 999, 999);
+      final DateTime result = utcNow.subtractMonths(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 4, 15, 23, 59, 59, 999, 999));
+    });
+
+    test('subtractMonths with UTC DateTime crosses year boundary', () {
+      final DateTime utcNow = DateTime.utc(2024, 2, 15, 12, 30, 45);
+      final DateTime result = utcNow.subtractMonths(3);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 11, 15, 12, 30, 45));
+    });
+
+    test('subtractMonths with UTC DateTime requires day clamping', () {
+      final DateTime utcNow = DateTime.utc(2024, 3, 31, 15, 45, 30);
+      final DateTime result = utcNow.subtractMonths(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 2, 29, 15, 45, 30)); // leap year
+    });
+
+    test('subtractMonths with UTC DateTime from leap day', () {
+      final DateTime utcNow = DateTime.utc(2024, 2, 29, 10, 15, 20);
+      final DateTime result = utcNow.subtractMonths(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 1, 29, 10, 15, 20));
+    });
+
+    test('subtractMonths with UTC DateTime to non-leap year February', () {
+      final DateTime utcNow = DateTime.utc(2024, 3, 29, 8, 30, 15);
+      final DateTime result = utcNow.subtractMonths(13); // goes to 2023
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 2, 28, 8, 30, 15)); // clamped to Feb 28
+    });
+
+    test('subtractMonths UTC with zero months returns identical UTC DateTime',
+        () {
+      final DateTime utcNow = DateTime.utc(2024, 4, 15, 16, 45, 30, 123, 456);
+      final DateTime result = utcNow.subtractMonths(0);
+      expect(result.isUtc, true);
+      expect(result, utcNow);
+      expect(identical(result, utcNow), false); // should be new instance
+    });
+
+    test('subtractMonths UTC chained operations preserve UTC flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 12, 31, 23, 59, 59);
+      final DateTime result = utcNow
+          .subtractMonths(1) // Nov 30
+          .subtractMonths(2) // Sep 30
+          .subtractMonths(3); // Jun 30
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 6, 30, 23, 59, 59));
+    });
+
+    test('subtractMonths UTC with negative value (adding months)', () {
+      final DateTime utcNow = DateTime.utc(2024, 1, 31, 12, 0, 0);
+      final DateTime result = utcNow.subtractMonths(-1); // add 1 month
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 2, 29, 12, 0, 0)); // clamped to Feb 29
+    });
+
+    test('subtractMonths UTC with very large value spans multiple years', () {
+      final DateTime utcNow = DateTime.utc(2024, 6, 15, 9, 30, 45);
+      final DateTime result = utcNow.subtractMonths(30); // 2.5 years
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2021, 12, 15, 9, 30, 45));
+    });
+
+    test('subtractMonth getter preserves UTC with complex time', () {
+      final DateTime utcNow = DateTime.utc(2024, 8, 15, 18, 45, 30, 750, 500);
+      final DateTime result = utcNow.subtractMonth;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 7, 15, 18, 45, 30, 750, 500));
+    });
+
+    test('subtractMonths UTC mixed with local DateTime operations', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 31, 14, 30, 0);
+      final DateTime localNow = DateTime(2024, 5, 31, 14, 30, 0);
+
+      final DateTime utcResult = utcNow.subtractMonths(1);
+      final DateTime localResult = localNow.subtractMonths(1);
+
+      expect(utcResult.isUtc, true);
+      expect(localResult.isUtc, false);
+      expect(utcResult, DateTime.utc(2024, 4, 30, 14, 30, 0));
+      expect(localResult, DateTime(2024, 4, 30, 14, 30, 0));
+    });
+
+    test('subtractMonths UTC from January 1st crosses year boundary', () {
+      final DateTime utcNow = DateTime.utc(2024, 1, 1, 0, 0, 0);
+      final DateTime result = utcNow.subtractMonths(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 12, 1, 0, 0, 0));
+    });
+
+    test('subtractMonths UTC with millisecond precision preservation', () {
+      final DateTime utcNow = DateTime.utc(2024, 10, 31, 11, 22, 33, 444);
+      final DateTime result = utcNow.subtractMonths(2);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2024, 8, 31, 11, 22, 33, 444));
+    });
+
+    test('subtractMonths UTC handles February edge case in leap year', () {
+      final DateTime utcNow = DateTime.utc(2024, 4, 30, 20, 15, 10);
+      final DateTime result = utcNow.subtractMonths(2); // goes to Feb
+      expect(result.isUtc, true);
+      expect(
+          result, DateTime.utc(2024, 2, 29, 20, 15, 10)); // Feb 29 in leap year
+    });
+
+    test('subtractMonths UTC handles February edge case in non-leap year', () {
+      final DateTime utcNow = DateTime.utc(2023, 4, 30, 20, 15, 10);
+      final DateTime result = utcNow.subtractMonths(2); // goes to Feb 2023
+      expect(result.isUtc, true);
+      expect(result,
+          DateTime.utc(2023, 2, 28, 20, 15, 10)); // Feb 28 in non-leap year
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Edge Cases', () {
+    test('subtractMonths with very large value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(120); // 10 years
+      expect(result, DateTime(2014, 6, 15));
+    });
+
+    test('subtractMonths going back to year 1', () {
+      final DateTime now = DateTime(5, 3, 15);
+      final DateTime result = now.subtractMonths(50);
+      expect(result, DateTime(1, 1, 15));
+    });
+
+    test('subtractMonths with day 1 never needs clamping', () {
+      final DateTime now = DateTime(2024, 3, 1);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 2, 1));
+    });
+
+    test('subtractMonths from February 28 to January 28', () {
+      final DateTime now = DateTime(2024, 2, 28);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 1, 28));
+    });
+
+    test('subtractMonths from February 29 to January 29', () {
+      final DateTime now = DateTime(2024, 2, 29);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 1, 29));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Negative Values', () {
+    test('subtractMonths with negative value adds months', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractMonths(-2);
+      expect(result, DateTime(2024, 5, 15));
+    });
+
+    test('subtractMonths with negative value crosses year boundary', () {
+      final DateTime now = DateTime(2023, 11, 15);
+      final DateTime result = now.subtractMonths(-3);
+      expect(result, DateTime(2024, 2, 15));
+    });
+
+    test('subtractMonths with negative value requires day clamping', () {
+      final DateTime now = DateTime(2024, 1, 31);
+      final DateTime result =
+          now.subtractMonths(-1); // equivalent to adding 1 month
+      expect(result, DateTime(2024, 2, 29)); // clamped to Feb 29 in leap year
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Complex Scenarios', () {
+    test('subtractMonths multiple times in sequence', () {
+      final DateTime now = DateTime(2024, 12, 31);
+      final DateTime result = now
+          .subtractMonths(1) // Nov 30
+          .subtractMonths(1) // Oct 30
+          .subtractMonths(1); // Sep 30
+      expect(result, DateTime(2024, 9, 30));
+    });
+
+    test('subtractMonths with day clamping chain', () {
+      final DateTime now = DateTime(2024, 5, 31);
+      final DateTime result = now
+          .subtractMonths(1) // April 30 (clamped)
+          .subtractMonths(1) // March 30
+          .subtractMonths(1); // February 29 (clamped, leap year)
+      expect(result, DateTime(2024, 2, 29));
+    });
+
+    test('subtractMonths preserves milliseconds and microseconds', () {
+      final DateTime now = DateTime(2024, 6, 15, 10, 30, 45, 123, 456);
+      final DateTime result = now.subtractMonths(3);
+      expect(result, DateTime(2024, 3, 15, 10, 30, 45, 123, 456));
+    });
+
+    test('subtractMonths from end of month to shorter month multiple times',
+        () {
+      final DateTime now = DateTime(2024, 7, 31);
+      final DateTime result = now
+          .subtractMonths(1) // June 30
+          .subtractMonths(1) // May 30
+          .subtractMonths(3); // February 29
+      expect(result, DateTime(2024, 2, 29));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Month-Year Edge Cases', () {
+    test('subtractMonths from January 1 to December of previous year', () {
+      final DateTime now = DateTime(2024, 1, 1);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2023, 12, 1));
+    });
+
+    test('subtractMonths exactly 12 months', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(12);
+      expect(result, DateTime(2023, 6, 15));
+    });
+
+    test('subtractMonths with 13 months', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(13);
+      expect(result, DateTime(2023, 5, 15));
+    });
+
+    test('subtractMonths from leap day to non-leap year', () {
+      final DateTime now = DateTime(2024, 2, 29); // leap year
+      final DateTime result = now.subtractMonths(12);
+      expect(
+          result, DateTime(2023, 2, 28)); // clamped to Feb 28 in non-leap year
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Performance Edge Cases', () {
+    test('subtractMonths with very large negative value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractMonths(-240); // adding 20 years
+      expect(result, DateTime(2044, 6, 15));
+    });
+
+    test('subtractMonths alternating positive and negative', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now
+          .subtractMonths(6) // Dec 2023
+          .subtractMonths(-3) // Mar 2024
+          .subtractMonths(2); // Jan 2024
+      expect(result, DateTime(2024, 1, 15));
+    });
+
+    test('subtractMonths preserves exact time down to microseconds', () {
+      final DateTime now = DateTime(2024, 8, 31, 23, 59, 59, 999, 999);
+      final DateTime result = now.subtractMonths(1);
+      expect(result, DateTime(2024, 7, 31, 23, 59, 59, 999, 999));
+    });
+  });
+}

--- a/test/date_time/subtract/years_test.dart
+++ b/test/date_time/subtract/years_test.dart
@@ -1,0 +1,393 @@
+import 'package:test/test.dart';
+import 'package:time_plus/time_plus.dart';
+
+void main() {
+  group('DateTimeSubtractMonthsAndYearsExtension - Basic Year Subtraction', () {
+    test('subtractYears returns correct DateTime for simple case', () {
+      final DateTime now = DateTime(2024, 6, 15, 10, 30, 45);
+      final DateTime result = now.subtractYears(2);
+      expect(result, DateTime(2022, 6, 15, 10, 30, 45));
+    });
+
+    test('subtractYears with single year', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractYears(1);
+      expect(result, DateTime(2023, 3, 15));
+    });
+
+    test('subtractYears preserves time components', () {
+      final DateTime now = DateTime(2024, 6, 15, 14, 25, 30, 500, 250);
+      final DateTime result = now.subtractYears(3);
+      expect(result, DateTime(2021, 6, 15, 14, 25, 30, 500, 250));
+    });
+
+    test('subtractYears with zero years returns same DateTime', () {
+      final DateTime now = DateTime(2024, 4, 15, 10, 30);
+      final DateTime result = now.subtractYears(0);
+      expect(result, now);
+    });
+
+    test('subtractYear getter works correctly', () {
+      final DateTime now = DateTime(2024, 5, 15);
+      final DateTime result = now.subtractYear;
+      expect(result, DateTime(2023, 5, 15));
+    });
+
+    test('subtractYears preserves month and day', () {
+      final DateTime now = DateTime(2024, 12, 25, 18, 45);
+      final DateTime result = now.subtractYears(5);
+      expect(result, DateTime(2019, 12, 25, 18, 45));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Leap Year Handling', () {
+    test('subtractYears from leap day to non-leap year clamps to Feb 28', () {
+      final DateTime now = DateTime(2024, 2, 29, 12, 30); // leap year
+      final DateTime result = now.subtractYears(1);
+      expect(result, DateTime(2023, 2, 28, 12, 30)); // clamped to Feb 28
+    });
+
+    test('subtractYears from leap day to another leap year preserves Feb 29',
+        () {
+      final DateTime now = DateTime(2024, 2, 29, 15, 45); // leap year
+      final DateTime result = now.subtractYears(4);
+      expect(result, DateTime(2020, 2, 29, 15, 45)); // another leap year
+    });
+
+    test('subtractYears from non-leap year to leap year preserves Feb 28', () {
+      final DateTime now = DateTime(2023, 2, 28, 9, 15); // non-leap year
+      final DateTime result = now.subtractYears(1);
+      expect(result, DateTime(2022, 2, 28, 9, 15)); // non-leap year
+    });
+
+    test('subtractYears from March 1 in leap year to non-leap year', () {
+      final DateTime now = DateTime(2024, 3, 1, 10, 0); // day after leap day
+      final DateTime result = now.subtractYears(1);
+      expect(result, DateTime(2023, 3, 1, 10, 0)); // March 1 in non-leap year
+    });
+
+    test('subtractYears multiple leap year cycles', () {
+      final DateTime now = DateTime(2024, 2, 29, 14, 30); // leap year
+      final DateTime result = now.subtractYears(8); // 2 leap year cycles
+      expect(result, DateTime(2016, 2, 29, 14, 30)); // another leap year
+    });
+
+    test('subtractYears from leap day to century year (non-leap)', () {
+      final DateTime now = DateTime(2004, 2, 29, 16, 20); // leap year
+      final DateTime result = now.subtractYears(4);
+      expect(result, DateTime(2000, 2, 29, 16, 20)); // century leap year
+    });
+
+    test('subtractYears handles century non-leap year correctly', () {
+      final DateTime now = DateTime(2004, 2, 29, 11, 45); // leap year
+      final DateTime result = now.subtractYears(104);
+      expect(result, DateTime(1900, 2, 28, 11, 45)); // 1900 was not a leap year
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Day Clamping Edge Cases',
+      () {
+    test('subtractYears preserves valid days when no clamping needed', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractYears(10);
+      expect(result, DateTime(2014, 6, 15));
+    });
+
+    test('subtractYears from Feb 29 to multiple non-leap years', () {
+      final DateTime now = DateTime(2024, 2, 29); // leap year
+      final DateTime result1 = now.subtractYears(1); // 2023 - non-leap
+      final DateTime result2 = now.subtractYears(2); // 2022 - non-leap
+      final DateTime result3 = now.subtractYears(3); // 2021 - non-leap
+
+      expect(result1, DateTime(2023, 2, 28));
+      expect(result2, DateTime(2022, 2, 28));
+      expect(result3, DateTime(2021, 2, 28));
+    });
+
+    test('subtractYears preserves all other days throughout year', () {
+      final testDates = [
+        DateTime(2024, 1, 31), // Jan 31
+        DateTime(2024, 3, 31), // Mar 31
+        DateTime(2024, 4, 30), // Apr 30
+        DateTime(2024, 5, 31), // May 31
+        DateTime(2024, 6, 30), // Jun 30
+        DateTime(2024, 7, 31), // Jul 31
+        DateTime(2024, 8, 31), // Aug 31
+        DateTime(2024, 9, 30), // Sep 30
+        DateTime(2024, 10, 31), // Oct 31
+        DateTime(2024, 11, 30), // Nov 30
+        DateTime(2024, 12, 31), // Dec 31
+      ];
+
+      for (final date in testDates) {
+        final result = date.subtractYears(3);
+        expect(result.year, 2021);
+        expect(result.month, date.month);
+        expect(result.day, date.day);
+      }
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Large Year Values', () {
+    test('subtractYears with very large value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractYears(100);
+      expect(result, DateTime(1924, 6, 15));
+    });
+
+    test('subtractYears spanning multiple centuries', () {
+      final DateTime now = DateTime(2024, 7, 4, 12, 0);
+      final DateTime result = now.subtractYears(424);
+      expect(result, DateTime(1600, 7, 4, 12, 0));
+    });
+
+    test('subtractYears going back to year 1', () {
+      final DateTime now = DateTime(2024, 12, 25);
+      final DateTime result = now.subtractYears(2023);
+      expect(result, DateTime(1, 12, 25));
+    });
+
+    test('subtractYears with millennium span', () {
+      final DateTime now = DateTime(2024, 1, 1, 0, 0);
+      final DateTime result = now.subtractYears(1024);
+      expect(result, DateTime(1000, 1, 1, 0, 0));
+    });
+  });
+
+  group(
+      'DateTimeSubtractMonthsAndYearsExtension - UTC and Timezone Preservation',
+      () {
+    test('subtractYears preserves UTC flag when true', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15, 10, 30);
+      final DateTime result = utcNow.subtractYears(3);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2021, 5, 15, 10, 30));
+    });
+
+    test('subtractYears preserves local timezone when false', () {
+      final DateTime localNow = DateTime(2024, 5, 15, 10, 30);
+      final DateTime result = localNow.subtractYears(2);
+      expect(result.isUtc, false);
+      expect(result, DateTime(2022, 5, 15, 10, 30));
+    });
+
+    test('subtractYear getter preserves UTC flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 5, 15);
+      final DateTime result = utcNow.subtractYear;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 5, 15));
+    });
+
+    test('subtractYears UTC with leap day clamping', () {
+      final DateTime utcNow = DateTime.utc(2024, 2, 29, 14, 30, 45);
+      final DateTime result = utcNow.subtractYears(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 2, 28, 14, 30, 45));
+    });
+
+    test('subtractYears preserves exact UTC time components', () {
+      final DateTime utcNow = DateTime.utc(2024, 8, 15, 23, 59, 59, 999, 999);
+      final DateTime result = utcNow.subtractYears(5);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2019, 8, 15, 23, 59, 59, 999, 999));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Negative Values', () {
+    test('subtractYears with negative value adds years', () {
+      final DateTime now = DateTime(2024, 3, 15);
+      final DateTime result = now.subtractYears(-5);
+      expect(result, DateTime(2029, 3, 15));
+    });
+
+    test('subtractYears with negative value from non-leap to leap year', () {
+      final DateTime now = DateTime(2023, 2, 28); // non-leap year
+      final DateTime result =
+          now.subtractYears(-1); // equivalent to adding 1 year
+      expect(result, DateTime(2024, 2, 28)); // Feb 28 preserved in leap year
+    });
+
+    test('subtractYears with negative value requires day clamping', () {
+      final DateTime now = DateTime(2023, 2, 28);
+      final DateTime result =
+          now.subtractYears(-1); // add 1 year to reach 2024 (leap year)
+      expect(result,
+          DateTime(2024, 2, 28)); // should stay Feb 28, not become Feb 29
+    });
+
+    test('subtractYears with large negative value', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractYears(-50);
+      expect(result, DateTime(2074, 6, 15));
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Complex Scenarios', () {
+    test('subtractYears multiple times in sequence', () {
+      final DateTime now = DateTime(2024, 7, 15, 16, 30);
+      final DateTime result = now
+          .subtractYears(1) // 2023
+          .subtractYears(2) // 2021
+          .subtractYears(3); // 2018
+      expect(result, DateTime(2018, 7, 15, 16, 30));
+    });
+
+    test('subtractYears chained with leap day handling', () {
+      final DateTime now = DateTime(2024, 2, 29, 12, 0); // leap day
+      final DateTime result = now
+          .subtractYears(1) // 2023, Feb 28 (clamped)
+          .subtractYears(1) // 2022, Feb 28
+          .subtractYears(2); // 2020, Feb 28 (even though 2020 is leap year)
+      expect(result, DateTime(2020, 2, 28, 12, 0));
+    });
+
+    test('subtractYears preserves milliseconds and microseconds', () {
+      final DateTime now = DateTime(2024, 9, 21, 14, 35, 45, 123, 456);
+      final DateTime result = now.subtractYears(7);
+      expect(result, DateTime(2017, 9, 21, 14, 35, 45, 123, 456));
+    });
+
+    test('subtractYears alternating positive and negative', () {
+      final DateTime now = DateTime(2024, 4, 10);
+      final DateTime result = now
+          .subtractYears(5) // 2019
+          .subtractYears(-2) // 2021
+          .subtractYears(1); // 2020
+      expect(result, DateTime(2020, 4, 10));
+    });
+
+    test('subtractYears with year boundaries at different months', () {
+      final dates = [
+        DateTime(2024, 1, 15), // January
+        DateTime(2024, 6, 15), // June
+        DateTime(2024, 12, 15), // December
+      ];
+
+      for (final date in dates) {
+        final result = date.subtractYears(10);
+        expect(result.year, 2014);
+        expect(result.month, date.month);
+        expect(result.day, date.day);
+      }
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Historical Year Edge Cases',
+      () {
+    test('subtractYears handles various century boundaries', () {
+      final DateTime now = DateTime(2024, 3, 15);
+
+      // Test going back to different centuries
+      expect(now.subtractYears(24), DateTime(2000, 3, 15)); // Y2K
+      expect(
+          now.subtractYears(124), DateTime(1900, 3, 15)); // 20th century start
+      expect(
+          now.subtractYears(224), DateTime(1800, 3, 15)); // 19th century start
+    });
+
+    test('subtractYears from current year to various historical periods', () {
+      final DateTime now = DateTime(2024, 7, 4, 12, 0); // Independence Day
+
+      // Various historical spans
+      expect(
+          now.subtractYears(50), DateTime(1974, 7, 4, 12, 0)); // 50 years ago
+      expect(
+          now.subtractYears(100), DateTime(1924, 7, 4, 12, 0)); // 100 years ago
+      expect(now.subtractYears(248),
+          DateTime(1776, 7, 4, 12, 0)); // US Independence
+    });
+
+    test('subtractYears handles leap year in year 2000', () {
+      final DateTime now = DateTime(2004, 2, 29); // leap year
+      final DateTime result = now.subtractYears(4);
+      expect(result,
+          DateTime(2000, 2, 29)); // 2000 was a leap year (divisible by 400)
+    });
+
+    test('subtractYears handles non-leap century year 1900', () {
+      final DateTime now = DateTime(2000, 2, 29); // leap year
+      final DateTime result = now.subtractYears(100);
+      expect(
+          result,
+          DateTime(1900, 2,
+              28)); // 1900 was not a leap year (divisible by 100 but not 400)
+    });
+  });
+
+  group('DateTimeSubtractMonthsAndYearsExtension - Performance and Edge Cases',
+      () {
+    test('subtractYears with very large value preserves precision', () {
+      final DateTime now = DateTime(2024, 11, 11, 11, 11, 11, 111, 111);
+      final DateTime result = now.subtractYears(1000);
+      expect(result, DateTime(1024, 11, 11, 11, 11, 11, 111, 111));
+    });
+
+    test('subtractYear getter with complex DateTime', () {
+      final DateTime now = DateTime(2024, 8, 31, 23, 59, 59, 999, 999);
+      final DateTime result = now.subtractYear;
+      expect(result, DateTime(2023, 8, 31, 23, 59, 59, 999, 999));
+    });
+
+    test('subtractYears creates new instance, not reference', () {
+      final DateTime now = DateTime(2024, 6, 15);
+      final DateTime result = now.subtractYears(0);
+      expect(result, now);
+      expect(identical(result, now), false);
+    });
+
+    test('subtractYears with mixed operations on same DateTime', () {
+      final DateTime base = DateTime(2024, 5, 15, 10, 30);
+
+      final result1 = base.subtractYears(1);
+      final result2 = base.subtractYears(2);
+      final result3 = base.subtractYears(3);
+
+      expect(result1, DateTime(2023, 5, 15, 10, 30));
+      expect(result2, DateTime(2022, 5, 15, 10, 30));
+      expect(result3, DateTime(2021, 5, 15, 10, 30));
+
+      // Original should be unchanged
+      expect(base, DateTime(2024, 5, 15, 10, 30));
+    });
+  });
+
+  group(
+      'DateTimeSubtractMonthsAndYearsExtension - Comprehensive UTC Years Tests',
+      () {
+    test('subtractYears UTC with leap day to non-leap year', () {
+      final DateTime utcNow = DateTime.utc(2024, 2, 29, 18, 45, 30);
+      final DateTime result = utcNow.subtractYears(1);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 2, 28, 18, 45, 30));
+    });
+
+    test('subtractYears UTC preserves exact time across centuries', () {
+      final DateTime utcNow = DateTime.utc(2024, 12, 31, 23, 59, 59, 999);
+      final DateTime result = utcNow.subtractYears(124);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(1900, 12, 31, 23, 59, 59, 999));
+    });
+
+    test('subtractYears UTC chained operations preserve flag', () {
+      final DateTime utcNow = DateTime.utc(2024, 6, 15, 12, 0, 0);
+      final DateTime result =
+          utcNow.subtractYears(2).subtractYears(3).subtractYears(5);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2014, 6, 15, 12, 0, 0));
+    });
+
+    test('subtractYear getter preserves UTC with microsecond precision', () {
+      final DateTime utcNow = DateTime.utc(2024, 3, 15, 9, 30, 45, 123, 456);
+      final DateTime result = utcNow.subtractYear;
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2023, 3, 15, 9, 30, 45, 123, 456));
+    });
+
+    test('subtractYears UTC handles year 2000 leap year correctly', () {
+      final DateTime utcNow = DateTime.utc(2004, 2, 29, 6, 15, 30);
+      final DateTime result = utcNow.subtractYears(4);
+      expect(result.isUtc, true);
+      expect(result, DateTime.utc(2000, 2, 29, 6, 15, 30)); // 2000 is leap year
+    });
+  });
+}

--- a/test/date_time/utc_flag_test.dart
+++ b/test/date_time/utc_flag_test.dart
@@ -1,0 +1,351 @@
+import 'package:test/test.dart';
+import 'package:time_plus/src/date_time/utc_flag.dart';
+
+void main() {
+  group('DateTimeSameTimeZoneExtensions', () {
+    group('withSameZone', () {
+      test('creates UTC DateTime when original is UTC', () {
+        final original = DateTime.utc(2023, 1, 1, 12, 30);
+
+        final result = original.withSameUtcFlag(2024, 2, 3, 4, 5, 6, 7, 8);
+
+        expect(result.isUtc, true);
+        expect(result.year, 2024);
+        expect(result.month, 2);
+        expect(result.day, 3);
+        expect(result.hour, 4);
+        expect(result.minute, 5);
+        expect(result.second, 6);
+        expect(result.millisecond, 7);
+        expect(result.microsecond, 8);
+      });
+
+      test('creates local DateTime when original is local', () {
+        final original = DateTime(2023, 1, 1, 12, 30);
+
+        final result = original.withSameUtcFlag(2024, 2, 3, 4, 5, 6, 7, 8);
+
+        expect(result.isUtc, false);
+        expect(result.year, 2024);
+        expect(result.month, 2);
+        expect(result.day, 3);
+        expect(result.hour, 4);
+        expect(result.minute, 5);
+        expect(result.second, 6);
+        expect(result.millisecond, 7);
+        expect(result.microsecond, 8);
+      });
+
+      test('uses default values for unspecified parameters with UTC', () {
+        final original = DateTime.utc(2023, 1, 1);
+
+        // Only year specified
+        var result = original.withSameUtcFlag(2024);
+        expect(result.isUtc, true);
+        expect(result.year, 2024);
+        expect(result.month, 1);
+        expect(result.day, 1);
+        expect(result.hour, 0);
+        expect(result.minute, 0);
+        expect(result.second, 0);
+        expect(result.millisecond, 0);
+        expect(result.microsecond, 0);
+
+        // Year and month specified
+        result = original.withSameUtcFlag(2024, 5);
+        expect(result.isUtc, true);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 1);
+
+        // Year, month, and day specified
+        result = original.withSameUtcFlag(2024, 5, 15);
+        expect(result.isUtc, true);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 15);
+
+        // Year, month, day, and hour specified
+        result = original.withSameUtcFlag(2024, 5, 15, 10);
+        expect(result.isUtc, true);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 15);
+        expect(result.hour, 10);
+      });
+
+      test('uses default values for unspecified parameters with local', () {
+        final original = DateTime(2023, 1, 1);
+
+        // Only year specified
+        var result = original.withSameUtcFlag(2024);
+        expect(result.isUtc, false);
+        expect(result.year, 2024);
+        expect(result.month, 1);
+        expect(result.day, 1);
+        expect(result.hour, 0);
+        expect(result.minute, 0);
+        expect(result.second, 0);
+        expect(result.millisecond, 0);
+        expect(result.microsecond, 0);
+
+        // Year and month specified
+        result = original.withSameUtcFlag(2024, 5);
+        expect(result.isUtc, false);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 1);
+
+        // Year, month, and day specified
+        result = original.withSameUtcFlag(2024, 5, 15);
+        expect(result.isUtc, false);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 15);
+
+        // Year, month, day, and hour specified
+        result = original.withSameUtcFlag(2024, 5, 15, 10);
+        expect(result.isUtc, false);
+        expect(result.year, 2024);
+        expect(result.month, 5);
+        expect(result.day, 15);
+        expect(result.hour, 10);
+      });
+
+      test('preserves timezone characteristics', () {
+        final utcTime = DateTime.utc(2023, 1, 1);
+        final localTime = DateTime(2023, 1, 1);
+
+        // Ensure different instances maintain their timezone
+        final utcResult = utcTime.withSameUtcFlag(2024);
+        final localResult = localTime.withSameUtcFlag(2024);
+
+        expect(utcResult.isUtc, true);
+        expect(localResult.isUtc, false);
+      });
+
+      test('handles edge cases for dates', () {
+        final utcTime = DateTime.utc(2023, 1, 1);
+        final localTime = DateTime(2023, 1, 1);
+
+        // Leap year date
+        var utcResult = utcTime.withSameUtcFlag(2024, 2, 29);
+        var localResult = localTime.withSameUtcFlag(2024, 2, 29);
+
+        expect(utcResult.month, 2);
+        expect(utcResult.day, 29);
+        expect(localResult.month, 2);
+        expect(localResult.day, 29);
+
+        // Month boundaries
+        utcResult = utcTime.withSameUtcFlag(2023, 12, 31, 23, 59, 59, 999, 999);
+        localResult =
+            localTime.withSameUtcFlag(2023, 12, 31, 23, 59, 59, 999, 999);
+
+        expect(utcResult.year, 2023);
+        expect(utcResult.month, 12);
+        expect(utcResult.day, 31);
+        expect(utcResult.hour, 23);
+        expect(utcResult.minute, 59);
+        expect(utcResult.second, 59);
+        expect(utcResult.millisecond, 999);
+        expect(utcResult.microsecond, 999);
+
+        expect(localResult.year, 2023);
+        expect(localResult.month, 12);
+        expect(localResult.day, 31);
+        expect(localResult.hour, 23);
+        expect(localResult.minute, 59);
+        expect(localResult.second, 59);
+        expect(localResult.millisecond, 999);
+        expect(localResult.microsecond, 999);
+      });
+
+      test('compares equal to manually constructed equivalent DateTime', () {
+        final utcOriginal = DateTime.utc(2023, 5, 15, 10, 30, 45);
+        final localOriginal = DateTime(2023, 5, 15, 10, 30, 45);
+
+        final utcResult =
+            utcOriginal.withSameUtcFlag(2024, 6, 20, 12, 35, 50, 500, 600);
+        final utcManual = DateTime.utc(2024, 6, 20, 12, 35, 50, 500, 600);
+
+        final localResult =
+            localOriginal.withSameUtcFlag(2024, 6, 20, 12, 35, 50, 500, 600);
+        final localManual = DateTime(2024, 6, 20, 12, 35, 50, 500, 600);
+
+        expect(utcResult, equals(utcManual));
+        expect(localResult, equals(localManual));
+      });
+
+      test('chaining withSameZone calls works correctly', () {
+        final utcOriginal = DateTime.utc(2023, 1, 1);
+        final localOriginal = DateTime(2023, 1, 1);
+
+        final utcResult = utcOriginal
+            .withSameUtcFlag(2024)
+            .withSameUtcFlag(2025, 2)
+            .withSameUtcFlag(2026, 3, 4)
+            .withSameUtcFlag(2027, 4, 5, 6);
+
+        final localResult = localOriginal
+            .withSameUtcFlag(2024)
+            .withSameUtcFlag(2025, 2)
+            .withSameUtcFlag(2026, 3, 4)
+            .withSameUtcFlag(2027, 4, 5, 6);
+
+        expect(utcResult.isUtc, true);
+        expect(utcResult.year, 2027);
+        expect(utcResult.month, 4);
+        expect(utcResult.day, 5);
+        expect(utcResult.hour, 6);
+
+        expect(localResult.isUtc, false);
+        expect(localResult.year, 2027);
+        expect(localResult.month, 4);
+        expect(localResult.day, 5);
+        expect(localResult.hour, 6);
+      });
+
+      test('works with distant past dates (BCE)', () {
+        final utcOriginal = DateTime.utc(2023, 1, 1);
+        final localOriginal = DateTime(2023, 1, 1);
+
+        // Note: DateTime in Dart supports years 0-9999, so -1000 is not valid
+        // Instead, we'll test with early years
+        final utcResult = utcOriginal.withSameUtcFlag(1, 1, 1);
+        final localResult = localOriginal.withSameUtcFlag(1, 1, 1);
+
+        expect(utcResult.isUtc, true);
+        expect(utcResult.year, 1);
+        expect(utcResult.month, 1);
+        expect(utcResult.day, 1);
+
+        expect(localResult.isUtc, false);
+        expect(localResult.year, 1);
+        expect(localResult.month, 1);
+        expect(localResult.day, 1);
+      });
+
+      test('works with extreme future dates', () {
+        final utcOriginal = DateTime.utc(2023, 1, 1);
+        final localOriginal = DateTime(2023, 1, 1);
+
+        // Test with year 9999 (max supported by DateTime)
+        final utcResult = utcOriginal.withSameUtcFlag(9999, 12, 31, 23, 59, 59);
+        final localResult =
+            localOriginal.withSameUtcFlag(9999, 12, 31, 23, 59, 59);
+
+        expect(utcResult.isUtc, true);
+        expect(utcResult.year, 9999);
+        expect(utcResult.month, 12);
+        expect(utcResult.day, 31);
+        expect(utcResult.hour, 23);
+        expect(utcResult.minute, 59);
+        expect(utcResult.second, 59);
+
+        expect(localResult.isUtc, false);
+        expect(localResult.year, 9999);
+        expect(localResult.month, 12);
+        expect(localResult.day, 31);
+        expect(localResult.hour, 23);
+        expect(localResult.minute, 59);
+        expect(localResult.second, 59);
+      });
+
+      test('works with different months having different day counts', () {
+        final utcOriginal = DateTime.utc(2023, 1, 1);
+        final localOriginal = DateTime(2023, 1, 1);
+
+        // Test with various month lengths (30, 31, 28, 29 days)
+        final months = [
+          [4, 30], // April - 30 days
+          [1, 31], // January - 31 days
+          [2, 28], // February 2023 - 28 days
+          [2, 29], // February 2024 (leap year) - 29 days
+        ];
+
+        for (final monthData in months) {
+          final month = monthData[0];
+          final lastDay = monthData[1];
+          final year = month == 2 && lastDay == 29 ? 2024 : 2023;
+
+          final utcResult = utcOriginal.withSameUtcFlag(year, month, lastDay);
+          final localResult =
+              localOriginal.withSameUtcFlag(year, month, lastDay);
+
+          expect(utcResult.year, year,
+              reason: 'Year should be $year for month $month');
+          expect(utcResult.month, month, reason: 'Month should be $month');
+          expect(utcResult.day, lastDay,
+              reason: 'Day should be $lastDay for month $month');
+
+          expect(localResult.year, year,
+              reason: 'Year should be $year for month $month');
+          expect(localResult.month, month, reason: 'Month should be $month');
+          expect(localResult.day, lastDay,
+              reason: 'Day should be $lastDay for month $month');
+        }
+      });
+
+      test(
+          'preserves timezone information when using all parameter combinations',
+          () {
+        final utcOriginal = DateTime.utc(2023, 1, 1);
+        final localOriginal = DateTime(2023, 1, 1);
+
+        // Generate all possible parameter combinations
+        final parameterCombos = [
+          [2024],
+          [2024, 2],
+          [2024, 2, 3],
+          [2024, 2, 3, 4],
+          [2024, 2, 3, 4, 5],
+          [2024, 2, 3, 4, 5, 6],
+          [2024, 2, 3, 4, 5, 6, 7],
+          [2024, 2, 3, 4, 5, 6, 7, 8],
+        ];
+
+        for (final params in parameterCombos) {
+          final utcResult = _callWithSameZone(utcOriginal, params);
+          final localResult = _callWithSameZone(localOriginal, params);
+
+          expect(utcResult.isUtc, true,
+              reason:
+                  'UTC timezone should be preserved with ${params.length} parameters');
+          expect(localResult.isUtc, false,
+              reason:
+                  'Local timezone should be preserved with ${params.length} parameters');
+        }
+      });
+    });
+  });
+}
+
+/// Helper function to call withSameZone with a dynamic number of parameters
+DateTime _callWithSameZone(DateTime original, List<int> params) {
+  switch (params.length) {
+    case 1:
+      return original.withSameUtcFlag(params[0]);
+    case 2:
+      return original.withSameUtcFlag(params[0], params[1]);
+    case 3:
+      return original.withSameUtcFlag(params[0], params[1], params[2]);
+    case 4:
+      return original.withSameUtcFlag(
+          params[0], params[1], params[2], params[3]);
+    case 5:
+      return original.withSameUtcFlag(
+          params[0], params[1], params[2], params[3], params[4]);
+    case 6:
+      return original.withSameUtcFlag(
+          params[0], params[1], params[2], params[3], params[4], params[5]);
+    case 7:
+      return original.withSameUtcFlag(params[0], params[1], params[2],
+          params[3], params[4], params[5], params[6]);
+    case 8:
+      return original.withSameUtcFlag(params[0], params[1], params[2],
+          params[3], params[4], params[5], params[6], params[7]);
+    default:
+      throw ArgumentError('Unsupported parameter count: ${params.length}');
+  }
+}

--- a/test/date_time/weekday_test.dart
+++ b/test/date_time/weekday_test.dart
@@ -105,10 +105,6 @@ void main() {
 
         final saturday = DateTime.utc(2024, 3, 23); // Saturday
 
-        print(saturday); // Should be 2024-03-23
-        print(saturday.yesterday); // Should be 2024-03-22
-        print(saturday.yesterday.weekday); // Should be 5
-
         expect(saturday.previousWeekday, equals(5)); // Friday
       });
 


### PR DESCRIPTION
- Added comprehensive `DateTime` subtraction extensions with calendar-aware date arithmetic
- Added `DateTimeSubtractMonthsAndYearsExtension` with `subtractMonths`, `subtractYears`, `subtractMonth`, `subtractYear` methods
- Added `DateTimeSubtractExtendingYearsExtension` with `subtractDecades`, `subtractCenturies`, `subtractDecade`, `subtractCentury` methods
- Works better than "adding minus days" or "adding minus weeks"
